### PR TITLE
feat(code/data): Implementing varied Lateral Thrusts

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2090,15 +2090,22 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		}
 		// Lateral Thrust functionality.
 		// This pulls "lateral thrust ratio" from the ship definition,
-		// and if there isn't one, it uses the default value of 0.25.
-		// Future thought: move this default into a gamerule or interfaces.txt
+		// and if there isn't one, it uses the default value of 0.25,
+		// which is listed as a gamerule value.
 		double latThrustCommand = commands.LateralThrust();
 		double latThrust = 0.;
 		double lateralThrustValue = 0.;
 		if(attributes.Get("lateral thrust ratio"))
 			lateralThrustValue = attributes.Get("lateral thrust ratio");
-		else if(!attributes.Get("lateral thrust ratio"))
-			lateralThrustValue = GameData::GetGamerules().DefaultLateralThrustRatio();
+		else if (!attributes.Get("lateral thrust ratio"))
+		{
+			// lateralThrustValue = GameData::GetGamerules().DefaultLateralThrustRatio();
+			if (mass < 3000)
+				lateralThrustValue = (3000 - mass) / 3500;
+			else
+				lateralThrustValue = 0.1;
+		}
+
 		if(latThrustCommand)
 		{
 			// Check if we are able to apply this thrust.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2100,7 +2100,7 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		else if (!attributes.Get("lateral thrust ratio"))
 		{
 			// lateralThrustValue = GameData::GetGamerules().DefaultLateralThrustRatio();
-			if (mass < 3000)
+			if (mass < 2500)
 				lateralThrustValue = (3000 - mass) / 3500;
 			else
 				lateralThrustValue = 0.1;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2097,10 +2097,10 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 		double lateralThrustValue = 0.;
 		if(attributes.Get("lateral thrust ratio"))
 			lateralThrustValue = attributes.Get("lateral thrust ratio");
-		else if (!attributes.Get("lateral thrust ratio"))
+		else if(!attributes.Get("lateral thrust ratio"))
 		{
 			// lateralThrustValue = GameData::GetGamerules().DefaultLateralThrustRatio();
-			if (mass < 2500)
+			if(mass < 2500)
 				lateralThrustValue = (3000 - mass) / 3500;
 			else
 				lateralThrustValue = 0.1;


### PR DESCRIPTION
The purpose of this PR is to implement a range of lateral thrusts across the entire ship ecosystem to see how things feel as a whole.

First attempt:
replacing the default 0.25 with `lateralThrustValue = (3000 - mass) / 3500;` or 0.1 if the mass is over 2500.

| Ship | Max Mass | Lateral Thrust Ratio |
| --------------- | --------------- | --------------- |
| Bactrian | 2210 | 0.23 |
| Carrier | 1830 | 0.33 |
| Dreadnought | 1520 | 0.42 |
| Falcon | 1180 | 0.52 |
| Osprey | 760 | 0.64 |
| Firebird | 740 | 0.65 |
| Hawk | 380 | 0.75 |
| Shuttle | 210 | 0.80 |
| Sparrow | 195 | 0.80 |
| Lance | 130 | 0.82 |

I'll just emphasize here that these aren't intended to be final values. This is just so that people can see what it feels like to have an environment where there's a broad range of different lateral thrust values, along the general principle that big ships have less lateral thrust (as a proportion of their overall thrust) than smaller ships.