### PR TITLE
rework scanning formula

### DIFF
--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
@@ -303,9 +303,9 @@ test "Launch Quarg Scanning Mission And Board"
 		# board the ship so we're sure we get close to it to get scanned
 		input
 			command board
-		# wait for 5 seconds so it should be repaired and have scanned us
+		# wait for 7.5 seconds so it should be repaired and have scanned us
 		apply
-			"test: steps to wait" = 10 * 30
+			"test: steps to wait" = 7 * 60 + 30
 		label "floating"
 		# empty input to make time pass
 		input


### PR DESCRIPTION
**Bugfix:** This un-nerfs scanners so they work again. I expect this fixes [#7640](https://github.com/endless-sky/endless-sky/issues/7640) and fixes [#8272](https://github.com/endless-sky/endless-sky/issues/8272).

**This is identical to my PR https://github.com/endless-sky/endless-sky/pull/8288 to endless-sky master.**

## Fix Details
Changes the scan formula to un-nerf scanners by using a gaussian drop-off and an adjusted size dependence. This retains the "minigame" from [#6193](https://github.com/endless-sky/endless-sky/pull/6193) of ten seconds and cargo/outfit size penalties. It also adds a minimum scan time of 2 seconds. Scanning a Bulk Freighter will take longer than scanning a Sparrow... but you *will* be able to scan it.

1. Minimum scan time of 2 seconds. A Sparrow in Hai space won't be scanned in one frame.
2. More reasonable size dependence: to scan a Bulk Freighter at the same speed as a Sparrow, you only need 6x as many scanners instead of 40x.
3. At full range, scans have a speed of 60% of maximum. Beyond this, it drops off much faster. This means they are *mostly effective within the normal range*.
4. Scans go out to about 2 x the reported scan range, at which point the scan speed is only 12%, but you still finish scanning in 10 seconds. This key change is what makes scanning missions doable. It is also critical due to a pair of AI bugs described below.
5. The numbers are tuned for a Navy surveillance gunship to take about 3 seconds to scan a light to medium warship sized craft in practical conditions.

This is balanced to allow well-designed early-game ships to do illegal missions with proper tactics; while scanning missions don't require dozens of scanners (just 10 seconds of patience).

## Testing Done
Used @Pointedstick's test save with a Splinter and various outfit scanner counts. Spent some time around navy ships to see if they can scan me, and if I could scan them. Everything seems to work about as well as it did before scanners were nerfed into oblivion. However, scan time of bigger ships is still decidedly longer than smaller ones, as intended.

### Free Worlds Scanning Mission

@Pointedstick's test save from [#7640](https://github.com/endless-sky/endless-sky/issues/7640) has a scanner-equipped Splinter at the "go scan that Cruiser" mission in the Free Worlds campaign. The mission is doable with one scanner, and easy with three.

[Morgan.Atrasco.txt](https://github.com/endless-sky/endless-sky/files/10549443/Morgan.Atrasco.txt)

### Illegal Missions

Here's another one from @movingpictures: a Heavy Shuttle up to no good, flying through *heavily* patrolled space:

[Lenny.Lightfingers](https://github.com/endless-sky/endless-sky/files/10611805/Lenny.Lightfingers.txt)

Here's four from me: Sparrow, Heavy Shuttle, Clipper, and Blackbird, outfitted for smuggling, all with illegal missions through well-patrolled space, and you don't have enough fuel to reach the destination.

[Aimet Taepip~3029-04-20 Sparrow Test.txt](https://github.com/endless-sky/endless-sky/files/10611903/Aimet.Taepip.3029-04-20.Sparrow.Test.txt)
[Aimet Taepip~3029-04-18 Heavy Shuttle Test.txt](https://github.com/endless-sky/endless-sky/files/10611902/Aimet.Taepip.3029-04-18.Heavy.Shuttle.Test.txt)
[Aimet Taepip~3029-04-18 Clipper Test.txt](https://github.com/endless-sky/endless-sky/files/10611904/Aimet.Taepip.3029-04-18.Clipper.Test.txt)
[Aimet Taepip~3029-04-18 Blackbird Test.txt](https://github.com/endless-sky/endless-sky/files/10611905/Aimet.Taepip.3029-04-18.Blackbird.Test.txt)

I'm able to do all the illegal missions, but I fail if I'm careless. You have to use the old tricks: run away from Navy ships and the Parrot, ramscoop in systems with red stars, refuel by boarding if possible, and never land until your destination. The ships are all quite fast, though the Blackbird relies on afterburners in an emergency.

### Big Ship Illegal Mission and AI Bugs

[Aimet Taepip~3029-04-19 Ranoerek Test.txt](https://github.com/endless-sky/endless-sky/files/10614015/Aimet.Taepip.3029-04-19.Ranoerek.Test.txt)

It generally takes the full ten seconds to scan my Ranoerek.