### PR TITLE
LocationFilter: conditions, reachable, mapped, elsewhere, entered, landed

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -578,6 +578,12 @@ void AI::Step(const PlayerInfo &player, Command &activeCommands)
 		bool isPresent = (it->GetSystem() == playerSystem);
 		bool isStranded = IsStranded(*it);
 		bool thisIsLaunching = (isPresent && HasDeployments(*it));
+
+		// Check if this ship's government has the authority to enforce scans & fines in this system.
+		if(!scanPermissions.count(gov))
+			scanPermissions.emplace(gov, gov && gov->CanEnforce(player, playerSystem));
+
+
 		if(isStranded || it->IsDisabled())
 		{
 			// Derelicts never ask for help (only the player should repair them).
@@ -4333,10 +4339,6 @@ void AI::UpdateStrengths(map<const Government *, int64_t> &strength, const Syste
 	for(const auto &it : ships)
 	{
 		const Government *gov = it->GetGovernment();
-
-		// Check if this ship's government has the authority to enforce scans & fines in this system.
-		if(!scanPermissions.count(gov))
-			scanPermissions.emplace(gov, gov && gov->CanEnforce(playerSystem));
 
 		// Only have ships update their strength estimate once per second on average.
 		if(!gov || it->GetSystem() != playerSystem || it->IsDisabled() || Random::Int(60))

--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -49,6 +49,20 @@ DistanceMap::DistanceMap(const System *center, WormholeStrategy wormholeStrategy
 
 
 
+// Find paths to the system containing the given ship. If the given
+// maximum count is above zero, it is a limit on how many systems
+// should be returned. If it is below zero it specifies the maximum
+// distance away that paths should be found.
+DistanceMap::DistanceMap(const Ship &ship, int maxCount, int maxDistance)
+	: center(ship.IsEnteringHyperspace() ? ship.GetTargetSystem() : ship.GetSystem()),
+	maxCount(maxCount), maxDistance(maxDistance)
+{
+	if(center)
+		Init(&ship);
+}
+
+
+
 // If a player is given, the map will only use hyperspace paths known to the
 // player; that is, one end of the path has been visited. Also, if the
 // player's flagship has a jump drive, the jumps will be make use of it.

--- a/source/DistanceMap.h
+++ b/source/DistanceMap.h
@@ -39,6 +39,11 @@ public:
 	// Find paths to the given system. The optional arguments put a limit on how
 	// many systems will be returned and how far away they are allowed to be.
 	explicit DistanceMap(const System *center, int maxCount = -1, int maxDistance = -1);
+	// Find paths to the ship's system, restricting the travel methods to
+	// what is possible with that ship. The optional arguments put a limit
+	// on how many systems will be returned and how far away they are
+	// allowed to be.
+	explicit DistanceMap(const Ship &ship, int maxCount = -1, int maxDistance = -1);
 	// Find paths to the given system, potentially using wormholes, a jump drive, or both.
 	// Optional arguments are as above.
 	explicit DistanceMap(const System *center, WormholeStrategy wormholeStrategy,

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -524,24 +524,26 @@ bool Government::Trusts(const Government *government) const
 
 
 
-// Returns true if this government has no enforcement restrictions, or if the
-// indicated system matches at least one enforcement zone.
-bool Government::CanEnforce(const System *system) const
+// Returns true if this government has no enforcement restrictions for
+// the given player at this system, or if the indicated system and
+// player matches at least one enforcement zone.
+bool Government::CanEnforce(const PlayerInfo &player, const System *system) const
 {
 	for(const LocationFilter &filter : enforcementZones)
-		if(filter.Matches(system))
+		if(filter.Matches(system, &player))
 			return true;
 	return enforcementZones.empty();
 }
 
 
 
-// Returns true if this government has no enforcement restrictions, or if the
-// indicated planet matches at least one enforcement zone.
-bool Government::CanEnforce(const Planet *planet) const
+// Returns true if this government has no enforcement restrictions for
+// the given player, or if the indicated planet matches at least one
+// enforcement zone for this player.
+bool Government::CanEnforce(const PlayerInfo &player, const Planet *planet) const
 {
 	for(const LocationFilter &filter : enforcementZones)
-		if(filter.Matches(planet))
+		if(filter.Matches(planet, &player))
 			return true;
 	return enforcementZones.empty();
 }

--- a/source/Government.h
+++ b/source/Government.h
@@ -95,8 +95,8 @@ public:
 	bool Trusts(const Government *other) const;
 	// A government might not exercise the ability to perform scans or fine
 	// the player in every system.
-	bool CanEnforce(const System *system) const;
-	bool CanEnforce(const Planet *planet) const;
+	bool CanEnforce(const PlayerInfo &player, const System *system) const;
+	bool CanEnforce(const PlayerInfo &player, const Planet *planet) const;
 	// Get the conversation that will be shown if this government gives a death
 	// sentence to the player (for carrying highly illegal cargo).
 	const Conversation *DeathSentence() const;

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -137,7 +137,7 @@ HailPanel::HailPanel(PlayerInfo &player, const StellarObject *object)
 	// to bypass language barriers.
 	if(planet && player.Flagship())
 		for(const Mission &mission : player.Missions())
-			if(mission.HasClearance(planet) && mission.ClearanceMessage() != "auto"
+			if(mission.HasClearance(player, planet) && mission.ClearanceMessage() != "auto"
 					&& mission.HasFullClearance())
 			{
 				planet->Bribe();

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -17,23 +17,34 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "CategoryList.h"
 #include "CategoryTypes.h"
+#include "ConditionSet.h"
 #include "DataNode.h"
 #include "DataWriter.h"
 #include "DistanceMap.h"
 #include "GameData.h"
 #include "Government.h"
 #include "Planet.h"
+#include "PlayerInfo.h"
 #include "Random.h"
 #include "Ship.h"
 #include "StellarObject.h"
 #include "System.h"
 
 #include <algorithm>
+#include <memory>
 #include <mutex>
+#include <stdexcept>
 
 using namespace std;
 
 namespace {
+	const int ENTERED = 1 << 0;
+	const int LANDED = 1 << 1;
+	const int REACHABLE = 1 << 2;
+	const int MAPPED = 1 << 3;
+	const int PLAYER_FILTERS = ENTERED | LANDED | REACHABLE | MAPPED;
+	const int ELSEWHERE = 1 << 4;
+
 	bool SetsIntersect(const set<string> &a, const set<string> &b)
 	{
 		// Quickest way to find out if two sets contain common elements: iterate
@@ -69,6 +80,53 @@ namespace {
 		}
 		return false;
 	}
+
+	shared_ptr<DistanceMap> FlagshipMap(const PlayerInfo &player)
+	{
+		static mutex distanceMutex;
+		lock_guard<mutex> lock(distanceMutex);
+
+		// Storing a weak pointer ensures that when the entire tree of LocationFilter
+		// methods exits, the DistanceMap is destructed and will be replaced upon the
+		// next call to the same LocationFilter tree.
+		static weak_ptr<DistanceMap> map;
+
+		try {
+			return shared_ptr<DistanceMap>(map);
+		}
+		catch(const bad_weak_ptr &bad)
+		{
+			// The last tree of LocationFilter methods exited, so we need a new map.
+			const Ship *flagship = player.Flagship();
+			shared_ptr<DistanceMap> made = (flagship ? make_shared<DistanceMap>(*flagship)
+				: make_shared<DistanceMap>(player));
+			map = made;
+			return made;
+		}
+	}
+
+	shared_ptr<DistanceMap> PlayerMap(const PlayerInfo &player)
+	{
+		static mutex distanceMutex;
+		lock_guard<mutex> lock(distanceMutex);
+
+		// Storing a weak pointer ensures that when the entire tree of LocationFilter
+		// methods exits, the DistanceMap is destructed and will be replaced upon the
+		// next call to the same LocationFilter tree.
+		static weak_ptr<DistanceMap> map;
+
+		try {
+			return shared_ptr<DistanceMap>(map);
+		}
+		catch(const bad_weak_ptr &bad)
+		{
+			// The last tree of LocationFilter methods exited, so we need a new map.
+			shared_ptr<DistanceMap> made = make_shared<DistanceMap>(player, nullptr);
+			map = made;
+			return made;
+		}
+	}
+
 
 	// Check if the given system is within the given distance of the center.
 	int Distance(const System *center, const System *system, int maximum, DistanceCalculationSettings distanceSettings)
@@ -109,13 +167,14 @@ namespace {
 
 	// Check that at least one neighbor of the hub system matches, for each of the neighbor filters.
 	// False if at least one filter fails to match, true if all filters find at least one match.
-	bool MatchesNeighborFilters(const list<LocationFilter> &neighborFilters, const System *hub, const System *origin)
+	bool MatchesNeighborFilters(const list<LocationFilter> &neighborFilters, const System *hub,
+			const System *origin, const PlayerInfo *player)
 	{
 		for(const LocationFilter &filter : neighborFilters)
 		{
 			bool hasMatch = false;
 			for(const System *neighbor : hub->Links())
-				if(filter.Matches(neighbor, origin))
+				if(filter.Matches(neighbor, player, origin))
 				{
 					hasMatch = true;
 					break;
@@ -191,7 +250,11 @@ void LocationFilter::Load(const DataNode &node)
 
 	isEmpty = planets.empty() && attributes.empty() && systems.empty() && governments.empty()
 		&& !center && originMaxDistance < 0 && notFilters.empty() && neighborFilters.empty()
-		&& outfits.empty() && shipCategory.empty();
+		&& outfits.empty() && shipCategory.empty() && !flags;
+
+	// Determine whether we'll need the player or flagship DistanceMaps will be needed.
+	if(!isEmpty)
+		UpdateMapFlags();
 }
 
 
@@ -272,6 +335,16 @@ void LocationFilter::Save(DataWriter &out) const
 		}
 		if(center)
 			out.Write("near", center->Name(), centerMinDistance, centerMaxDistance);
+		if((flags & ENTERED))
+			out.Write("entered");
+		if((flags & LANDED))
+			out.Write("landed");
+		if((flags & REACHABLE))
+			out.Write("reachable");
+		if((flags & MAPPED))
+			out.Write("mapped");
+		if((flags & ELSEWHERE))
+			out.Write("elsewhere");
 	}
 	out.EndChild();
 }
@@ -333,9 +406,12 @@ bool LocationFilter::IsValid() const
 
 
 // If the player is in the given system, does this filter match?
-bool LocationFilter::Matches(const Planet *planet, const System *origin) const
+bool LocationFilter::Matches(const Planet *planet, const PlayerInfo *player, const System *origin) const
 {
 	if(!planet || !planet->IsValid())
+		return false;
+
+	if((flags & ELSEWHERE) && planet->GetSystem() == origin)
 		return false;
 
 	// If a ship class was given, do not match planets.
@@ -352,7 +428,7 @@ bool LocationFilter::Matches(const Planet *planet, const System *origin) const
 			return false;
 
 	for(const LocationFilter &filter : notFilters)
-		if(filter.Matches(planet, origin))
+		if(filter.Matches(planet, player, origin))
 			return false;
 
 	// If outfits are specified, make sure they can be bought here.
@@ -360,25 +436,33 @@ bool LocationFilter::Matches(const Planet *planet, const System *origin) const
 		if(!SetsIntersect(outfitList, planet->Outfitter()))
 			return false;
 
-	return Matches(planet->GetSystem(), origin, true);
+	// Cache the maps to ensure methods lower in the tree do not recalculate them.
+	shared_ptr<DistanceMap> flagshipMap = (player && needFlagshipMap) ? FlagshipMap(*player) : nullptr;
+	shared_ptr<DistanceMap> playerMap = (player && needPlayerMap) ? PlayerMap(*player) : nullptr;
+
+	// Handle mapped, reachable, entered, landed, and conditions.
+	if(player && (flags & PLAYER_FILTERS) && !MatchesPlayerFilters(planet, player))
+		return false;
+
+	return Matches(planet->GetSystem(), player, origin, true);
 }
 
 
 
-bool LocationFilter::Matches(const System *system, const System *origin) const
+bool LocationFilter::Matches(const System *system, const PlayerInfo *player, const System *origin) const
 {
 	// If a ship class was given, do not match systems.
 	if(!shipCategory.empty())
 		return false;
 
-	return Matches(system, origin, false);
+	return Matches(system, player, origin, false);
 }
 
 
 
 // Check for matches with the ship's system, government, category,
 // outfits (installed and carried), and attributes.
-bool LocationFilter::Matches(const Ship &ship) const
+bool LocationFilter::Matches(const Ship &ship, const PlayerInfo *player) const
 {
 	const System *origin = ship.GetSystem();
 	if(!systems.empty() && !systems.count(origin))
@@ -416,16 +500,24 @@ bool LocationFilter::Matches(const Ship &ship) const
 				return false;
 	}
 
+	// Cache the maps to ensure methods lower in the tree do not recalculate them.
+	shared_ptr<DistanceMap> flagshipMap = (player && needFlagshipMap) ? FlagshipMap(*player) : nullptr;
+	shared_ptr<DistanceMap> playerMap = (player && needPlayerMap) ? PlayerMap(*player) : nullptr;
+
 	for(const LocationFilter &filter : notFilters)
-		if(filter.Matches(ship))
+		if(filter.Matches(ship, player))
 			return false;
 
-	if(!MatchesNeighborFilters(neighborFilters, origin, origin))
+	if(!MatchesNeighborFilters(neighborFilters, origin, origin, player))
 		return false;
 
 	// Check if this ship's current system meets a "near <system>" criterion.
 	// (Ships only offer missions, so no "distance" criteria need to be checked.)
 	if(center && Distance(center, origin, centerMaxDistance, centerDistanceOptions) < centerMinDistance)
+		return false;
+
+	// Handle mapped, reachable, entered, landed, and conditions.
+	if(player && (flags & PLAYER_FILTERS) && !MatchesPlayerFilters(origin, player))
 		return false;
 
 	return true;
@@ -463,8 +555,12 @@ LocationFilter LocationFilter::SetOrigin(const System *origin) const
 
 
 // Pick a random system that matches this filter, based on the given origin.
-const System *LocationFilter::PickSystem(const System *origin) const
+const System *LocationFilter::PickSystem(const System *origin, const PlayerInfo *player) const
 {
+	// Cache the maps to ensure methods lower in the tree do not recalculate them.
+	shared_ptr<DistanceMap> flagshipMap = (player && needFlagshipMap) ? FlagshipMap(*player) : nullptr;
+	shared_ptr<DistanceMap> playerMap = (player && needPlayerMap) ? PlayerMap(*player) : nullptr;
+
 	// Find a planet that satisfies the filter.
 	vector<const System *> options;
 	for(const auto &it : GameData::Systems())
@@ -473,7 +569,7 @@ const System *LocationFilter::PickSystem(const System *origin) const
 		// Skip systems with incomplete data or that are inaccessible.
 		if(!system.IsValid() || system.Inaccessible())
 			continue;
-		if(Matches(&system, origin))
+		if(Matches(&system, player, origin))
 			options.push_back(&system);
 	}
 	return options.empty() ? nullptr : options[Random::Int(options.size())];
@@ -482,8 +578,11 @@ const System *LocationFilter::PickSystem(const System *origin) const
 
 
 // Pick a random planet that matches this filter, based on the given origin.
-const Planet *LocationFilter::PickPlanet(const System *origin, bool hasClearance, bool requireSpaceport) const
+const Planet *LocationFilter::PickPlanet(const System *origin, const PlayerInfo *player,
+		bool hasClearance, bool requireSpaceport) const
 {
+	shared_ptr<DistanceMap> flagshipMap = (player && needFlagshipMap) ? FlagshipMap(*player) : nullptr;
+	shared_ptr<DistanceMap> playerMap = (player && needPlayerMap) ? PlayerMap(*player) : nullptr;
 	// Find a planet that satisfies the filter.
 	vector<const Planet *> options;
 	for(const auto &it : GameData::Planets())
@@ -496,7 +595,7 @@ const Planet *LocationFilter::PickPlanet(const System *origin, bool hasClearance
 		if(planet.IsWormhole() || (requireSpaceport && !planet.HasSpaceport()) || (!hasClearance && !planet.CanLand()))
 			if(planets.empty() || !planets.count(&planet))
 				continue;
-		if(Matches(&planet, origin))
+		if(Matches(&planet, player, origin))
 			options.push_back(&planet);
 	}
 	return options.empty() ? nullptr : options[Random::Int(options.size())];
@@ -513,6 +612,18 @@ void LocationFilter::LoadChild(const DataNode &child)
 	if(key == "not" || key == "neighbor")
 		child.PrintTrace("Error: Skipping unsupported use of 'not' and 'neighbor'."
 			" These keywords must be nested if used together.");
+	else if(key == "entered")
+		flags |= ENTERED;
+	else if(key == "landed")
+		flags |= LANDED;
+	else if(key == "reachable")
+		flags |= REACHABLE;
+	else if(key == "mapped")
+		flags |= MAPPED;
+	else if(key == "elsewhere")
+		flags |= ELSEWHERE;
+	else if(key == "test")
+		conditions.Load(child);
 	else if(key == "planet")
 	{
 		for(int i = valueIndex; i < child.Size(); ++i)
@@ -602,12 +713,18 @@ void LocationFilter::LoadChild(const DataNode &child)
 
 
 
-bool LocationFilter::Matches(const System *system, const System *origin, bool didPlanet) const
+bool LocationFilter::Matches(const System *system, const PlayerInfo *player, const System *origin, bool didPlanet) const
 {
 	if(!system || !system->IsValid())
 		return false;
+	if((flags & ELSEWHERE) && system == origin)
+		return false;
 	if(!systems.empty() && !systems.count(system))
 		return false;
+
+	// Cache the maps to ensure methods lower in the tree do not recalculate them.
+	shared_ptr<DistanceMap> flagshipMap = (player && needFlagshipMap) ? FlagshipMap(*player) : nullptr;
+	shared_ptr<DistanceMap> playerMap = (player && needPlayerMap) ? PlayerMap(*player) : nullptr;
 
 	// Don't check these filters again if they were already checked as a part of
 	// checking if a planet matches.
@@ -634,11 +751,11 @@ bool LocationFilter::Matches(const System *system, const System *origin, bool di
 		}
 
 		for(const LocationFilter &filter : notFilters)
-			if(filter.Matches(system, origin))
+			if(filter.Matches(system, player, origin))
 				return false;
 	}
 
-	if(!MatchesNeighborFilters(neighborFilters, system, origin))
+	if(!MatchesNeighborFilters(neighborFilters, system, origin, player))
 		return false;
 
 	// Check this system's distance from the desired reference system.
@@ -648,5 +765,99 @@ bool LocationFilter::Matches(const System *system, const System *origin, bool di
 			&& Distance(origin, system, originMaxDistance, originDistanceOptions) < originMinDistance)
 		return false;
 
+	// Handle mapped, reachable, entered, landed, and conditions.
+	if(!didPlanet && player && (flags & PLAYER_FILTERS) && !MatchesPlayerFilters(system, player))
+		return false;
 	return true;
+}
+
+
+
+bool LocationFilter::MatchesPlayerFilters(const System *system, const PlayerInfo *player) const
+{
+	if((flags & ENTERED) && !player->HasVisited(*system))
+		return false;
+	else if((flags & LANDED) && !Landed(system, player))
+		return false;
+	else if((flags & MAPPED) && !Mapped(system, player))
+		return false;
+	else if((flags & REACHABLE) && !Reachable(system, player))
+		return false;
+	else if(!conditions.IsEmpty() && !conditions.Test(player->Conditions()))
+		return false;
+	return true;
+}
+
+
+
+bool LocationFilter::MatchesPlayerFilters(const Planet *planet, const PlayerInfo *player) const
+{
+	if((flags & LANDED) && !player->HasVisited(*planet))
+		return false;
+
+	const System *system = planet->GetSystem();
+
+	if((flags & ENTERED) && !player->HasVisited(*system))
+		return false;
+	else if((flags & MAPPED) && !Mapped(system, player))
+		return false;
+	else if((flags & REACHABLE) && !Reachable(system, player))
+		return false;
+	else if(!conditions.IsEmpty() && !conditions.Test(player->Conditions()))
+		return false;
+	return true;
+}
+
+
+
+bool LocationFilter::Reachable(const System *system, const PlayerInfo *player)
+{
+	shared_ptr<DistanceMap> map = FlagshipMap(*player);
+	const Ship *flagship = player->Flagship();
+	return system && flagship && map->HasRoute(system);
+}
+
+
+
+bool LocationFilter::Landed(const System *system, const PlayerInfo *player)
+{
+	for(auto &object : system->Objects())
+		if(object.GetPlanet() && player->HasVisited(*object.GetPlanet()))
+			return true;
+	return false;
+}
+
+
+
+bool LocationFilter::Mapped(const System *system, const PlayerInfo *player)
+{
+	shared_ptr<DistanceMap> map = PlayerMap(*player);
+	const Ship *flagship = player->Flagship();
+	return system && flagship && map->HasRoute(system);
+}
+
+
+
+void LocationFilter::UpdateMapFlags()
+{
+	// Recurse through the tree to find whether we need the flagship or player maps.
+	needFlagshipMap = (flags & REACHABLE);
+	needPlayerMap = (flags & MAPPED);
+	if(needFlagshipMap && needPlayerMap)
+		return;
+
+	// Loop over the two lists, to reduce code complexity.
+	list<LocationFilter> *lists[2] = { &notFilters, &neighborFilters };
+	for(int i = 0; i < 2; ++i)
+		for(auto &filter : *lists[i])
+		{
+			// Recurse into child's UpdateMapFlags.
+			filter.UpdateMapFlags();
+			needFlagshipMap |= filter.needFlagshipMap;
+			needPlayerMap |= filter.needPlayerMap;
+
+			// If both maps are needed, there's nothing more to learn.
+			if(needFlagshipMap && needPlayerMap)
+				return;
+		}
 }

--- a/source/LocationFilter.h
+++ b/source/LocationFilter.h
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #ifndef LOCATION_FILTER_H_
 #define LOCATION_FILTER_H_
 
+#include "ConditionSet.h"
 #include "DistanceCalculationSettings.h"
 
 #include <list>
@@ -27,6 +28,7 @@ class DataWriter;
 class Government;
 class Outfit;
 class Planet;
+class PlayerInfo;
 class Ship;
 class System;
 
@@ -52,20 +54,26 @@ public:
 	bool IsEmpty() const;
 	bool IsValid() const;
 
+	// All public methods that take a PlayerInfo* can receive a nullptr, but
+	// that will disable all tests which require PlayerInfo. If a resulting
+	// LocationFilter has nothing else in it, it'll always match, which means
+	// a not filter of them will never match.
+
 	// If the player is in the given system, does this filter match?
-	bool Matches(const Planet *planet, const System *origin = nullptr) const;
-	bool Matches(const System *system, const System *origin = nullptr) const;
+	bool Matches(const Planet *planet, const PlayerInfo *player, const System *origin = nullptr) const;
+	bool Matches(const System *system, const PlayerInfo *player, const System *origin = nullptr) const;
 	// Ships are chosen based on system/"near" filters, government, category
 	// of ship, outfits installed/carried, and their total attributes.
-	bool Matches(const Ship &ship) const;
+	bool Matches(const Ship &ship, const PlayerInfo *player) const;
 
 	// Return a new LocationFilter with any "distance" conditions converted
 	// into "near" references, relative to the given system.
 	LocationFilter SetOrigin(const System *origin) const;
 	// Generic find system / find planet methods, based on the given origin
 	// system (e.g. the player's current system) and ability to land.
-	const System *PickSystem(const System *origin) const;
-	const Planet *PickPlanet(const System *origin, bool hasClearance = false, bool requireSpaceport = true) const;
+	const System *PickSystem(const System *origin, const PlayerInfo *player) const;
+	const Planet *PickPlanet(const System *origin, const PlayerInfo *player, bool hasClearance = false,
+		bool requireSpaceport = true) const;
 
 
 private:
@@ -74,7 +82,13 @@ private:
 	// Check if the filter matches the given system. If it did not, return true
 	// only if the filter wasn't looking for planet characteristics or if the
 	// didPlanet argument is set (meaning we already checked those).
-	bool Matches(const System *system, const System *origin, bool didPlanet) const;
+	bool Matches(const System *system, const PlayerInfo *player, const System *origin, bool didPlanet) const;
+	bool MatchesPlayerFilters(const System *system, const PlayerInfo *player) const;
+	bool MatchesPlayerFilters(const Planet *planet, const PlayerInfo *player) const;
+	static bool Reachable(const System *system, const PlayerInfo *player);
+	static bool Landed(const System *system, const PlayerInfo *player);
+	static bool Mapped(const System *system, const PlayerInfo *player);
+	void UpdateMapFlags();
 
 
 private:
@@ -98,6 +112,14 @@ private:
 	int originMaxDistance = -1;
 	DistanceCalculationSettings originDistanceOptions;
 
+	// Flags for keyword tests such as "elsewhere" or "landed"
+	int flags = 0;
+
+	// Do any filters in this tree need this map?
+	// This is an efficiency measure, so DistanceMaps are only calculated when needed.
+	bool needFlagshipMap = false;
+	bool needPlayerMap = false;
+
 	// At least one of the outfits from each set must be available
 	// (to purchase or plunder):
 	std::list<std::set<const Outfit *>> outfits;
@@ -108,6 +130,8 @@ private:
 	std::list<LocationFilter> notFilters;
 	// These filters store all the things the planet or system must border.
 	std::list<LocationFilter> neighborFilters;
+
+	ConditionSet conditions;
 };
 
 

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -700,14 +700,14 @@ bool Mission::CheckDeadline(const Date &today)
 
 
 
-// Check if you have special clearance to land on your destination.
-bool Mission::HasClearance(const Planet *planet) const
+// Check if the given player has special clearance to land on your destination.
+bool Mission::HasClearance(const PlayerInfo &player, const Planet *planet) const
 {
 	if(clearance.empty())
 		return false;
 	if(planet == destination || stopovers.count(planet) || visitedStopovers.count(planet))
 		return true;
-	return (!clearanceFilter.IsEmpty() && clearanceFilter.Matches(planet));
+	return (!clearanceFilter.IsEmpty() && clearanceFilter.Matches(planet, &player));
 }
 
 
@@ -738,7 +738,7 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 		if(!boardingShip)
 			return false;
 
-		if(!sourceFilter.Matches(*boardingShip))
+		if(!sourceFilter.Matches(*boardingShip, &player))
 			return false;
 	}
 	else
@@ -746,7 +746,7 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 		if(source && source != player.GetPlanet())
 			return false;
 
-		if(!sourceFilter.Matches(player.GetPlanet()))
+		if(!sourceFilter.Matches(player.GetPlanet(), &player))
 			return false;
 	}
 
@@ -1219,7 +1219,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	const System *const sourceSystem = player.GetSystem();
 	for(const LocationFilter &filter : waypointFilters)
 	{
-		const System *system = filter.PickSystem(sourceSystem);
+		const System *system = filter.PickSystem(sourceSystem, &player);
 		if(!system)
 			return result;
 		result.waypoints.insert(system);
@@ -1241,7 +1241,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	for(const LocationFilter &filter : stopoverFilters)
 	{
 		// Unlike destinations, we can allow stopovers on planets that don't have a spaceport.
-		const Planet *planet = filter.PickPlanet(sourceSystem, ignoreClearance || !clearance.empty(), false);
+		const Planet *planet = filter.PickPlanet(sourceSystem, &player, ignoreClearance || !clearance.empty(), false);
 		if(!planet)
 			return result;
 		result.stopovers.insert(planet);
@@ -1254,7 +1254,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	result.destination = destination;
 	if(!result.destination && !destinationFilter.IsEmpty())
 	{
-		result.destination = destinationFilter.PickPlanet(sourceSystem, ignoreClearance || !clearance.empty());
+		result.destination = destinationFilter.PickPlanet(sourceSystem, &player, ignoreClearance || !clearance.empty());
 		if(!result.destination)
 			return result;
 	}
@@ -1406,7 +1406,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 		return result;
 	}
 	for(const NPC &npc : npcs)
-		result.npcs.push_back(npc.Instantiate(subs, sourceSystem, result.destination->GetSystem(), jumps, payload));
+		result.npcs.push_back(npc.Instantiate(player, subs, sourceSystem, result.destination->GetSystem(), jumps, payload));
 
 	// Instantiate the actions. The "complete" action is always first so that
 	// the "<payment>" substitution can be filled in.

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -113,8 +113,8 @@ public:
 	// If this mission's deadline was before the given date and it has not been
 	// marked as failing already, mark it and return true.
 	bool CheckDeadline(const Date &today);
-	// Check if you have special clearance to land on your destination.
-	bool HasClearance(const Planet *planet) const;
+	// Check if the given player has special clearance to land on your destination.
+	bool HasClearance(const PlayerInfo &player, const Planet *planet) const;
 	// Get the string to be shown in the destination planet's hailing dialog. If
 	// this is "auto", you don't have to hail them to get landing permission.
 	const std::string &ClearanceMessage() const;

--- a/source/MissionAction.cpp
+++ b/source/MissionAction.cpp
@@ -274,7 +274,7 @@ bool MissionAction::CanBeDone(const PlayerInfo &player, const shared_ptr<Ship> &
 
 	// An `on enter` MissionAction may have defined a LocationFilter that
 	// specifies the systems in which it can occur.
-	if(!systemFilter.IsEmpty() && !systemFilter.Matches(player.GetSystem()))
+	if(!systemFilter.IsEmpty() && !systemFilter.Matches(player.GetSystem(), &player))
 		return false;
 	return true;
 }

--- a/source/NPC.cpp
+++ b/source/NPC.cpp
@@ -627,8 +627,8 @@ bool NPC::HasFailed() const
 
 // Create a copy of this NPC but with the fleets replaced by the actual
 // ships they represent, wildcards in the conversation text replaced, etc.
-NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const System *destination,
-		int jumps, int64_t payload) const
+NPC NPC::Instantiate(const PlayerInfo &player, map<string, string> &subs, const System *origin,
+		const System *destination, int jumps, int64_t payload) const
 {
 	NPC result;
 	result.government = government;
@@ -665,7 +665,7 @@ NPC NPC::Instantiate(map<string, string> &subs, const System *origin, const Syst
 	// Pick the system for this NPC to start out in.
 	result.system = system;
 	if(!result.system && !location.IsEmpty())
-		result.system = location.PickSystem(origin);
+		result.system = location.PickSystem(origin, &player);
 	if(!result.system)
 		result.system = (isAtDestination && destination) ? destination : origin;
 	// If a planet was specified in the template, it must be in this system.

--- a/source/NPC.h
+++ b/source/NPC.h
@@ -92,8 +92,8 @@ public:
 
 	// Create a copy of this NPC but with the fleets replaced by the actual
 	// ships they represent, wildcards in the conversation text replaced, etc.
-	NPC Instantiate(std::map<std::string, std::string> &subs, const System *origin, const System *destination,
-			int jumps, int64_t payload) const;
+	NPC Instantiate(const PlayerInfo &player, std::map<std::string, std::string> &subs, const System *origin,
+			const System *destination, int jumps, int64_t payload) const;
 
 
 private:

--- a/source/News.cpp
+++ b/source/News.cpp
@@ -16,6 +16,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "News.h"
 
 #include "DataNode.h"
+#include "PlayerInfo.h"
 #include "Random.h"
 #include "SpriteSet.h"
 
@@ -109,13 +110,19 @@ bool News::IsEmpty() const
 
 
 // Check if this news item is available given the player's planet and conditions.
-bool News::Matches(const Planet *planet, const ConditionsStore &conditions) const
+bool News::AvailableTo(const PlayerInfo &player) const
 {
 	// If no location filter is specified, it should never match. This can be
 	// used to create news items that are never shown until an event "activates"
 	// them by specifying their location.
 	// Similarly, by updating a news item with "remove location", it can be deactivated.
-	return location.IsEmpty() ? false : (location.Matches(planet) && toShow.Test(conditions));
+	if(location.IsEmpty())
+		return false;
+	else if(!location.Matches(player.GetPlanet(), &player))
+		return false;
+	else if(!toShow.Test(player.Conditions()))
+		return false;
+	return true;
 }
 
 

--- a/source/News.h
+++ b/source/News.h
@@ -24,7 +24,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 class DataNode;
-class Planet;
+class PlayerInfo;
 class Sprite;
 
 
@@ -37,8 +37,8 @@ public:
 
 	// Check whether this news item has anything to say.
 	bool IsEmpty() const;
-	// Check if this news item is available given the player's planet and conditions.
-	bool Matches(const Planet *planet, const ConditionsStore &conditions) const;
+	// Check if this news item is available to the given player.
+	bool AvailableTo(const PlayerInfo &player) const;
 
 	// Get the speaker's name.
 	std::string Name() const;

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -81,7 +81,7 @@ int Person::Frequency(const System *system) const
 	if(!system || IsDestroyed() || IsPlaced() || system->Links().empty())
 		return 0;
 
-	return (location.IsEmpty() || location.Matches(system)) ? frequency : 0;
+	return (location.IsEmpty() || location.Matches(system, nullptr)) ? frequency : 0;
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -4323,13 +4323,13 @@ void PlayerInfo::Fine(UI *ui)
 
 	// Planets should not fine you if you have mission clearance or are infiltrating.
 	for(const Mission &mission : missions)
-		if(mission.HasClearance(planet) || (!mission.HasFullClearance() &&
+		if(mission.HasClearance(*this, planet) || (!mission.HasFullClearance() &&
 					(mission.Destination() == planet || mission.Stopovers().count(planet))))
 			return;
 
 	// The planet's government must have the authority to enforce laws.
 	const Government *gov = planet->GetGovernment();
-	if(!gov->CanEnforce(planet))
+	if(!gov->CanEnforce(*this, planet))
 		return;
 
 	string message = gov->Fine(*this, 0, nullptr, planet->Security());

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -668,11 +668,11 @@ namespace {
 
 		cout << "Systems matching provided location filter:\n";
 		for(const auto &it : GameData::Systems())
-			if(filter.Matches(&it.second))
+			if(filter.Matches(&it.second, nullptr))
 				cout << it.first << '\n';
 		cout << "Planets matching provided location filter:\n";
 		for(const auto &it : GameData::Planets())
-			if(filter.Matches(&it.second))
+			if(filter.Matches(&it.second, nullptr))
 				cout << it.first << '\n';
 	}
 

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -115,10 +115,8 @@ void SpaceportPanel::Draw()
 const News *SpaceportPanel::PickNews() const
 {
 	vector<const News *> matches;
-	const Planet *planet = player.GetPlanet();
-	const auto &conditions = player.Conditions();
 	for(const auto &it : GameData::SpaceportNews())
-		if(!it.second.IsEmpty() && it.second.Matches(planet, conditions))
+		if(!it.second.IsEmpty() && it.second.AvailableTo(player))
 			matches.push_back(&it.second);
 
 	return matches.empty() ? nullptr : matches[Random::Int(matches.size())];


### PR DESCRIPTION
**Feature:** Location filters can have conditions, visit info, reachability, and other PlayerInfo things.

**This is identical to PR https://github.com/endless-sky/endless-sky/pull/8260 to endless-sky master.**

Related issues: [#7789](https://github.com/endless-sky/endless-sky/issues/7789), [#7702](https://github.com/endless-sky/endless-sky/issues/7702), [#5525](https://github.com/endless-sky/endless-sky/issues/5525), [#5395](https://github.com/endless-sky/endless-sky/issues/5395)

A previous attempt at visit-related features in a LocationFilter is: [#5415](https://github.com/endless-sky/endless-sky/pull/5415) and I have addressed the issues raised there.

## Feature Details
Connects PlayerInfo to LocationFilter, allowing this:

```ruby
mission
    ...
    destination
        elsewhere      # not at the center of the search (AKA not source)
        reachable      # player's flagship can get to the system, even if they don't know how
        mapped         # player has mapped a route to the system, even if their flagship can't get there
        entered        # player has entered (visited) the system
        landed         # player has landed on (visited) the planet
                       # (for a system filter: any planet in the system)

        # You can test conditions:
        test
            dog + cat == bunny

        # You can negate any of that:
        not landed
        not
             mapped
             reachable
             ...
    source
        ... # all that other stuff except "elsewhere" which would exclude the player's location
```

All those features will work in any location filters except person and the location test program. In those two, you can use `elsewhere` but not the others. However, the meaning of `elsewhere` depends on the context; it is always the center of the search.

## UI Screenshots
N/A

## Usage Examples
1. Multiple `not` blocks to select different regions based on conditions. This may let us merge multiple missions into one, when the difference was just source or destination
2. Remnant research missions can be restricted to `mapped` or `reachable` locations.
3. Jobs can be restricted to areas the player already knows about (`entered`, `landed`, `mapped`) to prevent accidentally giving away map information before it is time to.

## Testing Done
Lots of printfs, since the location test program has no PlayerInfo. (That can be dealt with in a later PR.)

Here are some examples:

[filtertest.txt](https://github.com/endless-sky/endless-sky/files/10543009/filtertest.txt)

### Automated Tests Added
N/A

## Performance Impact
No impact to existing features.

The `reachable` and `mapped` calculate a DistanceMap, which is expensive, so they should be restricted to mission destination/stopover/waypoint filters. If you use them in persons and enforcement zones, then things may get slow. I can't imagine how they'd be useful there... just sayin'.
