### PR TITLE
Fix movement bugs that break integration tests

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -2517,7 +2517,7 @@ void AI::MoveToAttack(Ship &ship, Command &command, const Body &target)
 		command.SetThrust(1.);
 
 	// Use an equipped afterburner if possible.
-	if(command.Has(Command::FORWARD) && direction.Length() < 1000. && ShouldUseAfterburner(ship))
+	if(command.Thrust() > 0 && direction.Length() < 1000. && ShouldUseAfterburner(ship))
 		command |= Command::AFTERBURNER;
 }
 
@@ -2546,7 +2546,7 @@ void AI::PickUp(Ship &ship, Command &command, const Body &target)
 
 	// Use the afterburner if it will not cause you to miss your target.
 	double squareDistance = p.LengthSquared();
-	if(command.Has(Command::FORWARD) && ShouldUseAfterburner(ship))
+	if(command.Thrust() > 0 && ShouldUseAfterburner(ship))
 		if(dp > max(.9, min(.9999, 1. - squareDistance / 10000000.)))
 			command |= Command::AFTERBURNER;
 }
@@ -3006,10 +3006,11 @@ bool AI::DoCloak(Ship &ship, Command &command)
 
 void AI::DoScatter(Ship &ship, Command &command)
 {
-	if(!command.Has(Command::FORWARD) && !command.Has(Command::BACK))
+	double thrust = command.Thrust();
+	if(!thrust)
 		return;
 
-	double flip = command.Has(Command::BACK) ? -1 : 1;
+	double flip = copysign(1, thrust);
 	double turnRate = ship.TurnRate();
 	double acceleration = ship.Acceleration();
 	// TODO: If there are many ships, use CollisionSet::Circle or another

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4505,7 +4505,7 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 				if((aNormal > 0.) != (vNormal > 0.) && fabs(aNormal) > fabs(vNormal))
 					dragAcceleration = -vNormal * angle.Unit();
 			}
-			if(velocity.Length() > MaxVelocity() || velocity.Length() < 0.1)
+			if(commands.Has(Command::STOP) || velocity.Length() > MaxVelocity() || velocity.Length() < 0.1)
 				velocity += dragAcceleration;
 			else
 				velocity += acceleration;

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4481,7 +4481,8 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 	if(acceleration)
 	{
 		acceleration *= slowMultiplier;
-		Point dragAcceleration = acceleration - velocity * (Drag() / mass);
+		double drag = Drag();
+		Point dragAcceleration = acceleration - velocity * (drag / mass);
 		// Make sure dragAcceleration has nonzero length, to avoid divide by zero.
 		if(dragAcceleration)
 		{
@@ -4503,12 +4504,17 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 				double vNormal = velocity.Dot(angle.Unit());
 				double aNormal = dragAcceleration.Dot(angle.Unit());
 				if((aNormal > 0.) != (vNormal > 0.) && fabs(aNormal) > fabs(vNormal))
-					dragAcceleration = -vNormal * angle.Unit();
+				{
+					velocity = acceleration = Point();
+					return;
+				}
 			}
-			if(commands.Has(Command::STOP) || velocity.Length() > MaxVelocity() || velocity.Length() < 0.1)
-				velocity += dragAcceleration;
-			else
-				velocity += acceleration;
+			double maxSpeedSquared = MaxVelocity();
+			maxSpeedSquared *= maxSpeedSquared;
+			double speedSquared = velocity.LengthSquared();
+			if(!commands.Has(Command::STOP) && speedSquared < maxSpeedSquared)
+				dragAcceleration *= 1 - (speedSquared / maxSpeedSquared);
+			velocity += dragAcceleration;
 		}
 		acceleration = Point();
 	}


### PR DESCRIPTION
**Bugfix:** Fixes #29 and some related problems mentioned on Discord

## Fix Details
1. Different drag logic to fix allow stopping to work reliably, while also allowing lateral thrusters to work as intended.
2. AI.cpp should use Command::Thrust(), not FORWARD and BACK.

## Testing Done
Ran the integration tests. Flew around a bit.

I ran the failing integration test ten times on an Ubuntu 22 GL build, and it passed.
