### PR TITLE
feat(fix): Fixing the discrepancy between the Settings panel sprite and the infoTable text

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -466,7 +466,7 @@ interface "controls"
 	sprite "ui/keys panel"
 		center -25 -20
 	sprite "ui/shift panel"
-		center -346 41
+		center -346 56
 	button c "_Controls"
 		center -300 -230
 		dimensions 90 30

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -589,7 +589,8 @@ void PreferencesPanel::DrawControls()
 	Table infoTable;
 	infoTable.AddColumn(125, {150, Alignment::RIGHT});
 	infoTable.SetUnderline(0, 130);
-	infoTable.DrawAt(Point(-400, 32));
+	// infoTable coordinates are Y axis (up/down), then X axis (left/right); -400,32
+	infoTable.DrawAt(Point(-400, 16));
 
 	infoTable.DrawUnderline(medium);
 	infoTable.Draw("Additional info", bright);

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -589,8 +589,8 @@ void PreferencesPanel::DrawControls()
 	Table infoTable;
 	infoTable.AddColumn(125, {150, Alignment::RIGHT});
 	infoTable.SetUnderline(0, 130);
-	// infoTable coordinates are Y axis (up/down), then X axis (left/right); -400,32
-	infoTable.DrawAt(Point(-400, 16));
+	// infoTable coordinates are Y axis (up/down), then X axis (left/right)
+	infoTable.DrawAt(Point(-400, 32));
 
 	infoTable.DrawUnderline(medium);
 	infoTable.Draw("Additional info", bright);


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug found while testing the updated Delta

## Summary
The infoTable text is offset from the shift table image. As such, the appropriate interface coordinates for it are moved down to fit it. As a minor side benefit, this brings our shift Table implementation close to being inline with upstream. Not a reason to do something in and of itself, but worth noting.

## Testing Done
In-game testing.

