### PR TITLE
feat(fix): Fixing the gimbal to work properly in some situation

### DIFF
--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -159,8 +159,7 @@ namespace {
 	void DrawFlareSprites(const Ship &ship, DrawList &draw, const vector<Ship::EnginePoint> &enginePoints,
 		const vector<pair<Body, int>> &flareSprites, uint8_t side)
 	{
-		double gimbalDirection = (ship.Commands().Has(Command::FORWARD) || ship.Commands().Has(Command::BACK))
-			* -ship.Commands().Turn();
+		double gimbalDirection = ship.Commands().Thrust() * -ship.Commands().Turn(); //  Commands().Thrust();
 
 		for(const Ship::EnginePoint &point : enginePoints)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4822,8 +4822,7 @@ void Ship::DoEngineVisuals(vector<Visual> &visuals, bool isUsingAfterburner)
 {
 	if(isUsingAfterburner && !Attributes().AfterburnerEffects().empty())
 	{
-		double gimbalDirection = (Commands().Has(Command::FORWARD) || Commands().Has(Command::BACK))
-			* -Commands().Turn();
+		double gimbalDirection = abs(Commands().Thrust()) * -Commands().Turn();
 
 		for(const EnginePoint &point : enginePoints)
 		{


### PR DESCRIPTION
**Bug fix**
The gimbaling behavior didn't work with Delta's simplified thrust system. 

By way of explanation for anyone not familiar with it, Delta, instead of having two separate "forward" and "backward" thrust, instead just has "Thrust" that can be any degree of positive or negative. Positive is forward, negative is backwards. Gimbaling expects to see "Forward" instead of "thrust", so it wasn't triggering properly.