### PR TITLE
Feat(data): Add 10% thrust to all reverse thrusters

### DIFF
--- a/data/_deprecated/deprecated outfits.txt
+++ b/data/_deprecated/deprecated outfits.txt
@@ -129,6 +129,9 @@ outfit "Reverse Thruster"
 	"mass" 22
 	"outfit space" -22
 	"weapon capacity" -22
+	"thrust" 1.868
+	"thrusting energy" 0.18
+	"thrusting heat" 0.35
 	"reverse thrust" 18.68
 	"reverse thrusting energy" 1.8
 	"reverse thrusting heat" 3.5

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -335,6 +335,12 @@ outfit "Small Reverse Module"
 	"mass" 9
 	"outfit space" -9
 	"weapon capacity" -9
+	"thrust" 0.9
+	"thrusting energy" 0.046
+	"thrusting heat" 0.3
+	"flare sprite" "effect/coalition flare/small"
+		"frame rate" 10
+	"flare sound" "atomic tiny"
 	"reverse thrust" 8.3
 	"reverse thrusting energy" 0.46
 	"reverse thrusting heat" 3
@@ -353,6 +359,12 @@ outfit "Large Reverse Module"
 	"mass" 32
 	"outfit space" -32
 	"weapon capacity" -32
+	"thrust" 3.06
+	"thrusting energy" 0.17
+	"thrusting heat" 1.1
+	"flare sprite" "effect/coalition flare/small"
+		"frame rate" 10
+	"flare sound" "atomic tiny"
 	"reverse thrust" 30.6
 	"reverse thrusting energy" 1.7
 	"reverse thrusting heat" 11

--- a/data/coalition/lunarium intro.txt
+++ b/data/coalition/lunarium intro.txt
@@ -1856,6 +1856,8 @@ mission "Lunarium: Questions"
 		not "joined the heliarchs"
 		not "assisting heliarchy"
 		not "assisting lunarium"
+	to complete
+		not "assisting heliarchy"
 	to fail
 		or
 			has "joined the heliarchs"
@@ -1865,6 +1867,8 @@ mission "Lunarium: Questions"
 			`As you prepare to land on <origin>, your monitor starts producing a low hum, stops, then starts again. This keeps up for nearly a minute until a message pops up. "Captain <last>, come to trust you our comrades have, thanks to your consistent help to our cause. Interested we are in your continuous support, so that free the Coalition, together we can. Come to <destination> you must. Meet with you, our leaders will, so that discuss an important task with them, you may. Have an available bunk in your ship, you should."`
 			`	The message cuts off shortly after you finish reading it. Your monitor is back to normal, and no humming sound can be heard. You mark <planet> on your map.`
 				accept
+	on visit
+		dialog `You are currently assisting the Heliarchy. Cancel or finish any missions you have for them if you want to join the Lunarium.`
 
 mission "Lunarium: Quarg Interview"
 	name "The Interview"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -689,6 +689,12 @@ outfit `"Basrem" Reverse Thruster`
 	"mass" 18
 	"outfit space" -18
 	"weapon capacity" -18
+	"thrust" 1.522
+	"thrusting energy" 0.14
+	"thrusting heat" 0.28
+	"flare sprite" "effect/atomic flare/tiny"
+		"frame rate" 14
+	"flare sound" "atomic tiny"
 	"reverse thrust" 15.22
 	"reverse thrusting energy" 1.4
 	"reverse thrusting heat" 2.8
@@ -704,6 +710,12 @@ outfit `"Benga" Reverse Thruster`
 	"mass" 28
 	"outfit space" -28
 	"weapon capacity" -28
+	"thrust" 2.515
+	"thrusting energy" 0.25
+	"thrusting heat" 0.48
+	"flare sprite" "effect/atomic flare/tiny"
+		"frame rate" 14
+	"flare sound" "atomic tiny"
 	"reverse thrust" 25.15
 	"reverse thrusting energy" 2.5
 	"reverse thrusting heat" 4.8
@@ -719,6 +731,12 @@ outfit `"Biroo" Reverse Thruster`
 	"mass" 44
 	"outfit space" -44
 	"weapon capacity" -44
+	"thrust" 4.165
+	"thrusting energy" 0.4
+	"thrusting heat" 0.82
+	"flare sprite" "effect/atomic flare/tiny"
+		"frame rate" 14
+	"flare sound" "atomic tiny"
 	"reverse thrust" 41.65
 	"reverse thrusting energy" 4
 	"reverse thrusting heat" 8.2

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -310,6 +310,12 @@ outfit "X1100 Ion Reverse Thruster"
 	"mass" 16
 	"outfit space" -16
 	"weapon capacity" -16
+	"thrust" 0.9
+	"thrusting energy" .06
+	"thrusting heat" .09
+	"flare sprite" "effect/ion flare/tiny"
+		"frame rate" 1.2
+	"flare sound" "ion tiny"
 	"reverse thrust" 9.03
 	"reverse thrusting energy" .6
 	"reverse thrusting heat" .9
@@ -512,6 +518,12 @@ outfit "Capybara Reverse Thruster"
 	"mass" 20
 	"outfit space" -20
 	"weapon capacity" -20
+	"thrust" 1.45
+	"thrusting energy" 0.1
+	"thrusting heat" 0.18
+	"flare sprite" "effect/plasma flare/tiny"
+		"frame rate" 5
+	"flare sound" "plasma tiny"
 	"reverse thrust" 14.5
 	"reverse thrusting energy" 1.0
 	"reverse thrusting heat" 1.8
@@ -704,6 +716,12 @@ outfit "AR120 Reverse Thruster"
 	"mass" 22
 	"outfit space" -22
 	"weapon capacity" -22
+	"thrust" 1.868
+	"thrusting energy" 0.18
+	"thrusting heat" 0.35
+	"flare sprite" "effect/atomic flare/tiny"
+		"frame rate" 14
+	"flare sound" "atomic tiny"
 	"reverse thrust" 18.68
 	"reverse thrusting energy" 1.8
 	"reverse thrusting heat" 3.5

--- a/data/human/kestrel.txt
+++ b/data/human/kestrel.txt
@@ -16,9 +16,12 @@ mission "Kestrel Testing"
 	description "Travel to the <waypoints> system to fight and disable a prototype warship that Tarazed Corporation is testing. Do not destroy the ship, or you will lose your payment and your opportunity to buy one."
 	source "Wayfarer"
 	waypoint "Umbral"
+	# The Kestrel is a secret that can only be unlocked after completing the rest of the game. Combat rating is used to track gameplay progression.
+	# After finding the Kestrel once, the threshold is lowered so players can use the ship during the human campaign on a later playthrough.
+	# Any requests to reduce the requirements will be rejected.
 	to offer
 		or
-			"combat rating" > 8000
+			"combat rating" > 6000
 			and
 				"combat rating" > 2000
 				has "global: unlocked kestrel"

--- a/data/korath/korath outfits.txt
+++ b/data/korath/korath outfits.txt
@@ -391,6 +391,12 @@ outfit "Bow Drive (Meteor Class)"
 	"outfit space" -18
 	"engine capacity" -15
 	"weapon capacity" -3
+	"thrust" 1.05
+	"thrusting energy" 0.135
+	"thrusting heat" 0.35
+	"flare sprite" "effect/korath flare/tiny"
+		"frame rate" 8
+	"flare sound" "plasma tiny"
 	"turn" 240
 	"turning energy" 0.65
 	"turning heat" 1.95
@@ -414,6 +420,12 @@ outfit "Reverser (Asteroid Class)"
 	"outfit space" -14
 	"engine capacity" -7
 	"weapon capacity" -7
+	"thrust" 1.384
+	"thrusting energy" 0.15
+	"thrusting heat" 0.34
+	"flare sprite" "effect/korath flare/tiny"
+		"frame rate" 8
+	"flare sound" "plasma tiny"
 	"reverse thrust" 13.84
 	"reverse thrusting energy" 1.5
 	"reverse thrusting heat" 3.4
@@ -432,6 +444,12 @@ outfit "Reverser (Comet Class)"
 	"outfit space" -24
 	"engine capacity" -12
 	"weapon capacity" -12
+	"thrust" 2.5
+	"thrusting energy" 0.28
+	"thrusting heat" 0.65
+	"flare sprite" "effect/korath flare/tiny"
+		"frame rate" 8
+	"flare sound" "plasma tiny"
 	"reverse thrust" 25.02
 	"reverse thrusting energy" 2.8
 	"reverse thrusting heat" 6.5
@@ -450,6 +468,12 @@ outfit "Reverser (Lunar Class)"
 	"outfit space" -40
 	"engine capacity" -20
 	"weapon capacity" -20
+	"thrust" 4.413
+	"thrusting energy" 0.49
+	"thrusting heat" 1.19
+	"flare sprite" "effect/korath flare/tiny"
+		"frame rate" 8
+	"flare sound" "plasma tiny"
 	"reverse thrust" 44.13
 	"reverse thrusting energy" 4.9
 	"reverse thrusting heat" 11.9
@@ -468,6 +492,12 @@ outfit "Reverser (Planetary Class)"
 	"outfit space" -68
 	"engine capacity" -34
 	"weapon capacity" -34
+	"thrust" 8
+	"thrusting energy" 0.89
+	"thrusting heat" 2.27
+	"flare sprite" "effect/korath flare/tiny"
+		"frame rate" 8
+	"flare sound" "plasma tiny"
 	"reverse thrust" 80.0
 	"reverse thrusting energy" 8.9
 	"reverse thrusting heat" 22.7
@@ -486,6 +516,12 @@ outfit "Reverser (Stellar Class)"
 	"outfit space" -118
 	"engine capacity" -59
 	"weapon capacity" -59
+	"thrust" 14.94
+	"thrusting energy" 1.58
+	"thrusting heat" 4.26
+	"flare sprite" "effect/korath flare/tiny"
+		"frame rate" 8
+	"flare sound" "plasma tiny"
 	"reverse thrust" 149.4
 	"reverse thrusting energy" 15.8
 	"reverse thrusting heat" 42.6

--- a/io.github.endless_sky.endless_sky.appdata.xml
+++ b/io.github.endless_sky.endless_sky.appdata.xml
@@ -6,6 +6,7 @@
   <summary>Space exploration and combat game</summary>
   <summary xml:lang="de">Weltraumhandels und Kampfsimulator</summary>
   <summary xml:lang="fr">Jeu d'exploration et de combat dans l'espace</summary>
+  <summary xml:lang="hu">Űrkutatási és harci játék</summary>
   <developer_name>Michael Zahniser</developer_name>
   <project_license>GPL-3.0-or-later</project_license>
   <metadata_license>CC0-1.0</metadata_license>
@@ -72,7 +73,7 @@
         <p>There's much more in the changelog!</p>
         <p>Special thanks to the 13 people who contributed to this release!</p>
       </description>
-      <url>https://github.comm/endless-sky/endless-sky/blob/v0.10.6/changelog</url>
+      <url>https://github.com/endless-sky/endless-sky/blob/v0.10.6/changelog</url>
     </release>
     <release version="0.10.5" date="2024-1-27" type="development" urgency="low">
       <description>

--- a/io.github.endless_sky.endless_sky.desktop
+++ b/io.github.endless_sky.endless_sky.desktop
@@ -4,6 +4,7 @@ Name=Endless Sky
 Comment=Space exploration and combat game
 Comment[de]=Weltraumhandels und Kampfsimulator
 Comment[fr]=Jeu d'exploration et de combat dans l'espace
+Comment[hu]=Űrkutatási és harci játék
 Exec=endless-sky
 Icon=endless-sky
 Type=Application

--- a/source/LoadPanel.cpp
+++ b/source/LoadPanel.cpp
@@ -43,8 +43,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <cstdlib>
-#include <iomanip>
-#include <sstream>
 #include <stdexcept>
 #include <utility>
 
@@ -71,17 +69,17 @@ namespace {
 	string TimestampString(time_t timestamp)
 	{
 		pair<const char*, const char*> format = TimestampFormatString(Preferences::GetDateFormat());
-		stringstream ss;
+		static const size_t BUF_SIZE = 25;
+		char str[BUF_SIZE];
 
 #ifdef _WIN32
 		tm date;
 		localtime_s(&date, &timestamp);
-		ss << std::put_time(&date, format.second);
+		return string(str, std::strftime(str, BUF_SIZE, format.second, &date));
 #else
 		const tm *date = localtime(&timestamp);
-		ss << std::put_time(date, format.first);
+		return string(str, std::strftime(str, BUF_SIZE, format.first, date));
 #endif
-		return ss.str();
 	}
 
 	// Extract the date from this pilot's most recent save.


### PR DESCRIPTION
## Summary

In parity to the station keeping changes that gave 10% reverse thrust to all thrusters, as well as the environmental lateral thrust; providing thrust to reverse thrusters.

It's a pretty tiny amount, so largely won't do much. Might even just muddy things unnecessarily.

On the other hand, in combination with the slot system, it means that getting a reverse thruster is one way to get a little bit more thrust, and every bit can help... Ironic that one gets more reverse thruster and thus becomes a more balanced ship overall, in pursuit of getting every last scrap of thrust...