### PR TITLE
Manta thruster slot fix

### DIFF
--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -2782,7 +2782,7 @@ ship "Manta"
 		"engine capacity" 100
 		"reverse thruster slot" 1
 		"steering slot" 1
-		"thruster slot" 1
+		"thruster slot" 2
 		weapon
 			"blast radius" 80
 			"shield damage" 800


### PR DESCRIPTION
**Bug fix**

This PR addresses the bug/feature described in https://github.com/endless-sky/Endless-Sky-Delta/pull/85#issuecomment-2386175687

## Summary
Added a thruster slot to the Manta.
Alternatively, we could have the Miner Manta specifically gain a thruster slot, but that doesn't make sense as a variant.
~~Or we could remove the extra engine.~~