### PR TITLE
feat(data): Move the starting year back by 1

### DIFF
--- a/data/starts.txt
+++ b/data/starts.txt
@@ -16,7 +16,7 @@ start "default"
 	description `You grew up on New Boston, an uninteresting world in the Dirt Belt. You've dreamed of owning a starship ever since your first visit to the spaceport at the age of fifteen. After many long years of working at a textile mill, you've finally saved enough credits to apply for a pilot's license from the Republic.`
 	description `	After receiving the license and with freedom from this planet at your fingertips, you travel to the bank to take out a loan on your first ship...`
 	thumbnail "scene/lobby"
-	date 16 11 3013
+	date 16 11 3012
 	system "Rutilicus"
 	planet "New Boston"
 	conversation "default intro"
@@ -74,7 +74,7 @@ start "hai space"
 		description `	Now, as your ferry docks at the main spaceport, you feel like this is the start of a new life as a captain.`
 		system "Fah Soom"
 		planet "Greenwater"
-		date 16 11 3013
+		date 16 11 3012
 		credits 1431000
 		debt 1431000
 	to unlock

--- a/data/starts.txt
+++ b/data/starts.txt
@@ -74,7 +74,7 @@ start "hai space"
 		description `	Now, as your ferry docks at the main spaceport, you feel like this is the start of a new life as a captain.`
 		system "Fah Soom"
 		planet "Greenwater"
-		date 16 5 3012
+		date 16 5 3013
 		credits 1431000
 		debt 1431000
 	to unlock

--- a/data/starts.txt
+++ b/data/starts.txt
@@ -16,7 +16,7 @@ start "default"
 	description `You grew up on New Boston, an uninteresting world in the Dirt Belt. You've dreamed of owning a starship ever since your first visit to the spaceport at the age of fifteen. After many long years of working at a textile mill, you've finally saved enough credits to apply for a pilot's license from the Republic.`
 	description `	After receiving the license and with freedom from this planet at your fingertips, you travel to the bank to take out a loan on your first ship...`
 	thumbnail "scene/lobby"
-	date 16 11 3012
+	date 16 5 3013
 	system "Rutilicus"
 	planet "New Boston"
 	conversation "default intro"
@@ -74,7 +74,7 @@ start "hai space"
 		description `	Now, as your ferry docks at the main spaceport, you feel like this is the start of a new life as a captain.`
 		system "Fah Soom"
 		planet "Greenwater"
-		date 16 11 3012
+		date 16 5 3012
 		credits 1431000
 		debt 1431000
 	to unlock


### PR DESCRIPTION
I have long considered the start of ES to be very rushed. The player has zero opportunity to really understand anything about the world when the bombing happens and the world is thrown into upheaval and civil war. The player has no chance to have figured out why they should even care to begin with. 

In previous testing I tried several time frames: six months earlier, 1 year earlier, 2 years earlier, 3 years earlier.

I found that six months to a year earlier yielded the best impact for me, as that gave me a chance to learn where some places are, get a feel for the problems currently affecting the universe (pirates and lack of navy patrols in the south, predominantly. The game *talks* about excessive regulations, but there's none of that to be seen that affects me.

I was going to set it to one year earlier (to keep the date the same, just a year earlier), but upon checking the autoconditions, and the game just tracks how many days into their piloting career the pilot is, not the actual date. So any missions based on that would be counting days, not checking for a date.

As such, I have opted to move the start date forward by six  (6) months to 3013-May-16. This gives the player, I feel, sufficient time to generate at least a partial internal image of the state of the Republic before things are made more complicated. This makes the events of the bombing much more impactful, as it increases the changes that the player has seen one or both of these places and can thus notice the change.