### PR TITLE
feat(code): Changes the [empty] label to identify what kind of hardpoint it is

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1479,3 +1479,6 @@ tip "Scroll speed"
 
 tip "Date format"
 	`The format that dates in the game are displayed in.`
+
+tip "Show parenthesis"
+	`Toggle parenthesis around the trade prices in the ports map mode.`

--- a/data/bunrodea/bunrodea weapons.txt
+++ b/data/bunrodea/bunrodea weapons.txt
@@ -50,7 +50,7 @@ outfit "Locust Turret"
 		sound "locust blaster"
 		"hit effect" "bullet impact"
 		"inaccuracy" 5
-		"turret turn" 6
+		"turret turn" 2
 		"velocity" 10
 		"random velocity" 2
 		"lifetime" 40

--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -58,7 +58,7 @@ outfit "Bombardment Turret"
 		sound "bombardment"
 		"hit effect" "bombardment impact"
 		"inaccuracy" 4
-		"turret turn" 2.8
+		"turret turn" 1.5
 		"velocity" 6
 		"random velocity" 1
 		"lifetime" 150
@@ -256,7 +256,7 @@ outfit "Heliarch Attractor"
 		sound "heliarch attractor"
 		"hit effect" "attractor impact"
 		"inaccuracy" 2
-		"turret turn" 4.1
+		"turret turn" 2
 		"velocity" 640
 		"lifetime" 1
 		"reload" 1
@@ -299,7 +299,7 @@ outfit "Heliarch Repulsor"
 		sound "heliarch repulsor"
 		"hit effect" "repulsor impact"
 		"inaccuracy" 3
-		"turret turn" 3.4
+		"turret turn" 1.5
 		"velocity" 560
 		"lifetime" 1
 		"reload" 1
@@ -339,7 +339,7 @@ outfit "Ion Hail Turret"
 		"hardpoint offset" 10.
 		sound "ion rain"
 		"inaccuracy" 3
-		"turret turn" 4.2
+		"turret turn" 1.9
 		"velocity" 12
 		"reload" 15
 		"burst reload" 3

--- a/data/gegno/gegno outfits.txt
+++ b/data/gegno/gegno outfits.txt
@@ -517,7 +517,7 @@ outfit "Choleric Cannon Turret"
 		"live effect" "choleric smoke" 24
 		"hit effect" "small explosion"
 		"inaccuracy" 2
-		"turret turn" 1.2
+		"turret turn" 1.3
 		"velocity" 9
 		"lifetime" 55
 		"reload" 80
@@ -602,7 +602,7 @@ outfit "Ballistic Cannon Turret"
 		"live effect" "ballistic smoke" 36
 		"hit effect" "ballistic hit"
 		"inaccuracy" 3
-		"turret turn" 0.6
+		"turret turn" 0.4
 		"velocity" 8
 		"lifetime" 100
 		"reload" 100
@@ -661,7 +661,7 @@ outfit "Astuit Battery"
 		sound "astuit"
 		"hit effect" "astuit hit"
 		"inaccuracy" 5
-		"turret turn" 2.2
+		"turret turn" 1.5
 		"velocity" 8
 		"lifetime" 44
 		"reload" 6
@@ -700,7 +700,7 @@ outfit "Acuit Artillery"
 		"hit effect" "acuit hit"
 		sound "acuit"
 		"inaccuracy" 3
-		"turret turn" 1.3
+		"turret turn" 0.7
 		"velocity" 18
 		"lifetime" 60
 		"reload" 60

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -78,7 +78,7 @@ outfit "Pulse Turret"
 		sound "pulse"
 		"hit effect" "pulse impact"
 		"inaccuracy" 1
-		"turret turn" 2.3
+		"turret turn" 1.5
 		"velocity" 15
 		"lifetime" 30
 		"reload" 10
@@ -208,7 +208,7 @@ outfit "Ionic Turret Prototype"
 		sound "ion"
 		"hit effect" "ionic impact" 5
 		"inaccuracy" 2
-		"turret turn" 2.4
+		"turret turn" 0.9
 		"velocity" 12
 		"lifetime" 70
 		"reload" 70

--- a/data/human/free worlds 2 middle.txt
+++ b/data/human/free worlds 2 middle.txt
@@ -204,6 +204,8 @@ mission "FW Southern Recon 1B"
 	autosave
 	source "Trinket"
 	destination "Trinket"
+	mark "Alnasl"
+	mark "Wei"
 	to offer
 		has "FW Southern Recon 1: done"
 	
@@ -232,6 +234,10 @@ mission "FW Southern Recon 1B"
 			names "republic small"
 			variant
 				"Gunboat (Mark II)"
+	on enter Alnasl
+		unmark Alnasl
+	on enter Wei
+		unmark Wei
 	to complete
 		not "FW Southern Recon 1B (Turret): done"
 	to fail

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -84,7 +84,7 @@ outfit "Blaster Turret"
 		sound "blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
-		"turret turn" 3.7
+		"turret turn" 2
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 6
@@ -110,7 +110,7 @@ outfit "Quad Blaster Turret"
 		sound "blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 3
-		"turret turn" 3.2
+		"turret turn" 1.5
 		"velocity" 10.625
 		"lifetime" 48
 		"reload" 3
@@ -202,7 +202,7 @@ outfit "Modified Blaster Turret"
 		sound "mod blaster"
 		"hit effect" "blaster impact"
 		"inaccuracy" 4
-		"turret turn" 3.5
+		"turret turn" 2
 		"velocity" 10
 		"lifetime" 48
 		"reload" 6
@@ -253,7 +253,7 @@ outfit "Laser Turret"
 		sound "laser"
 		"hit effect" "beam laser impact"
 		"inaccuracy" .5
-		"turret turn" 4.0
+		"turret turn" 2.2
 		"velocity" 300
 		"lifetime" 1
 		"reload" 1
@@ -313,7 +313,7 @@ outfit "Heavy Laser Turret"
 		sound "heavy laser"
 		"hit effect" "heavy laser impact"
 		"inaccuracy" .4
-		"turret turn" 2.2
+		"turret turn" 1.3
 		"velocity" 400
 		"lifetime" 1
 		"reload" 1
@@ -377,7 +377,7 @@ outfit "Mining Laser Turret"
 		sound "mining laser"
 		"hit effect" "beam laser impact"
 		"inaccuracy" .35
-		"turret turn" 3.8
+		"turret turn" 2.4
 		"velocity" 200
 		"lifetime" 1
 		"reload" 1
@@ -458,7 +458,7 @@ outfit "Electron Turret"
 		sound "electron beam"
 		"hit effect" "electron impact"
 		"inaccuracy" .3
-		"turret turn" 1.4
+		"turret turn" 0.8
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
@@ -630,7 +630,7 @@ outfit "Proton Turret"
 		sound "proton"
 		"hit effect" "proton impact" 3
 		"inaccuracy" 4
-		"turret turn" 2.0
+		"turret turn" 1.4
 		"submunition" "Proton Fragment" 3
 		"velocity" 24
 		"lifetime" 2
@@ -683,7 +683,7 @@ outfit "Plasma Turret"
 		sound "plasma"
 		"hit effect" "plasma explosion"
 		"inaccuracy" 2
-		"turret turn" 1.2
+		"turret turn" 1
 		"velocity" 12
 		"lifetime" 40
 		"reload" 9
@@ -1561,7 +1561,7 @@ outfit "Gatling Turret"
 		ammo "Gatling Gun Ammo" 2
 		icon "icon/gat turret"
 		"inaccuracy" 2
-		"turret turn" 3.4
+		"turret turn" 2
 		"velocity" 16
 		"lifetime" 1
 		"reload" 3

--- a/data/incipias/incipias outfits.txt
+++ b/data/incipias/incipias outfits.txt
@@ -67,7 +67,7 @@ outfit "Stagnation Beam"
 		sound "stagnation beam"
 		"hit effect" "stagnation beam impact"
 		"inaccuracy" .5
-		"turret turn" 3
+		"turret turn" 2.1
 		"velocity" 600
 		"lifetime" 1
 		"reload" 1

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -149,7 +149,7 @@ outfit "Ka'het Ravager Turret"
 		sound "disruptor"
 		"hit effect" "ravager impact"
 		"inaccuracy" .2
-		"turret turn" 1.8
+		"turret turn" 2.3
 		"velocity" 480
 		"lifetime" 1
 		"reload" 1
@@ -205,7 +205,7 @@ outfit "Ka'het Annihilator Turret"
 		"hardpoint offset" 15.
 		"hit effect" "bullet impact"
 		"inaccuracy" 1
-		"turret turn" 2.3
+		"turret turn" 1.8
 		"range override" 630
 		"velocity override" 18
 		"reload" 10

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -32,7 +32,7 @@ outfit "Grab-Strike Turret"
 		"hit effect" "grab-strike impact"
 		"die effect" "grab-strike impact"
 		"inaccuracy" 1
-		"turret turn" 1.9
+		"turret turn" 1
 		"velocity" 10
 		"lifetime" 100
 		"reload" 20
@@ -78,7 +78,7 @@ outfit "Shunt-Strike Turret"
 		"hit effect" "shunt-strike hit"
 		"die effect" "shunt-strike sparkle"
 		"inaccuracy" 1
-		"turret turn" 2.1
+		"turret turn" 1.5
 		"velocity" 10
 		"lifetime" 81
 		"reload" 30
@@ -132,7 +132,7 @@ outfit "Banisher Grav-Turret"
 		sound "banisher"
 		"hit effect" "banisher impact"
 		"inaccuracy" .4
-		"turret turn" 4.2
+		"turret turn" 1.8
 		"velocity" 590
 		"lifetime" 1
 		"reload" 1
@@ -255,7 +255,7 @@ outfit "Blaze-Pike Turret"
 		sound "blaze-pike"
 		"hit effect" "blaze-pike hit"
 		"inaccuracy" 0.45
-		"turret turn" 2.1
+		"turret turn" 0.8
 		"velocity" 450
 		"lifetime" 1
 		"reload" 1
@@ -293,7 +293,7 @@ outfit "Korath Inferno"
 		sound "korath inferno"
 		"hit effect" "korath inferno hit"
 		"inaccuracy" 0.5
-		"turret turn" 1.3
+		"turret turn" 0.6
 		"velocity" 550
 		"lifetime" 1
 		"reload" 1
@@ -372,7 +372,7 @@ outfit "Thermal Repeater Turret"
 		sound "repeater"
 		"hit effect" "repeater impact"
 		"inaccuracy" 3
-		"turret turn" 2.6
+		"turret turn" 1.5
 		"velocity" 13
 		"lifetime" 40
 		"reload" 5
@@ -654,7 +654,7 @@ outfit "Shield Disruptor Turret"
 		sound "disruptor"
 		"hit effect" "disruptor impact"
 		"inaccuracy" 1
-		"turret turn" 1.5
+		"turret turn" 1
 		"velocity" 480
 		"lifetime" 1
 		"reload" 1
@@ -718,7 +718,7 @@ outfit "Husk-Slice Turret"
 		sound "slicer"
 		"hit effect" "slicer impact"
 		"inaccuracy" 0
-		"turret turn" 2.9
+		"turret turn" 1.5
 		"velocity" 520
 		"lifetime" 1
 		"reload" 1.62
@@ -758,7 +758,7 @@ outfit "Digger Mining Turret"
 		sound "korath digger"
 		"hit effect" "korath digger hit"
 		"inaccuracy" 1.5
-		"turret turn" 4.6
+		"turret turn" 2.4
 		"velocity" 480
 		"lifetime" 1
 		"reload" 1
@@ -826,7 +826,7 @@ outfit "Langrage Hyper-Heaver"
 		icon "icon/korath heaver"
 		"hit effect" "heaver hyperspace hit"
 		"inaccuracy" 0.5
-		"turret turn" 2.2
+		"turret turn" 1.3
 		velocity 30
 		lifetime 8
 		"reload" 40
@@ -1084,7 +1084,7 @@ outfit "Firestorm Battery"
 		"hardpoint sprite" "hardpoint/firestorm battery"
 		sound "firestorm"
 		ammo "Firestorm Torpedo"
-		"turret turn" 2.7
+		"turret turn" 1.5
 		icon "icon/firestorm torpedo"
 		"hit effect" "firestorm ring" 40
 		"die effect" "small explosion"

--- a/data/pug/pug outfits.txt
+++ b/data/pug/pug outfits.txt
@@ -54,7 +54,7 @@ outfit "Pug Zapper Turret"
 		sound "zapper"
 		"hit effect" "zapper impact"
 		"inaccuracy" .3
-		"turret turn" 2.5
+		"turret turn" 1
 		"velocity" 320
 		"lifetime" 1
 		"reload" 1

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -50,7 +50,7 @@ outfit "Quarg Skylance"
 		sound "skylance"
 		"hit effect" "skylance impact"
 		"inaccuracy" .4
-		"turret turn" 4.
+		"turret turn" 1.5
 		"velocity" 500
 		"lifetime" 1
 		"reload" 1

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -76,7 +76,7 @@ outfit "Inhibitor Turret"
 		sound "inhibitor"
 		"hit effect" "inhibitor impact" 3
 		"inaccuracy" .5
-		"turret turn" 3.5
+		"turret turn" 2
 		"velocity" 36
 		"random velocity" .5
 		"lifetime" 24
@@ -152,7 +152,7 @@ outfit "Thrasher Turret"
 		sound "thrasher"
 		"hit effect" "thrasher impact"
 		"inaccuracy" 6
-		"turret turn" 2.4
+		"turret turn" 1.2
 		"velocity" 10
 		"lifetime" 36
 		"reload" 5

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -263,7 +263,7 @@ outfit "Particle Waveform Turret"
 		"fire effect" "lightning flare"
 		"hit effect" "pwave impact"
 		"inaccuracy" 1.5
-		"turret turn" 1.8
+		"turret turn" 0.8
 		"velocity" 50
 		"lifetime" 18
 		"reload" 60

--- a/data/successors/successor weapons.txt
+++ b/data/successors/successor weapons.txt
@@ -82,7 +82,7 @@ outfit "Bimodal Coilgun Turret"
 		"velocity" 30
 		"lifetime" 15
 		"range override" 900
-		"turret turn" 1.6
+		"turret turn" 0.7
 		"burst count" 24
 		"burst reload" 3
 		"reload" 15
@@ -229,7 +229,7 @@ outfit "Pulse Laser Turret"
 		"hit effect" "successor pulse laser impact"
 		"inaccuracy" 0.4
 		"velocity" 490
-		"turret turn" 2.5
+		"turret turn" 1.5
 		"lifetime" 1
 		"burst count" 9
 		"burst reload" 1
@@ -306,7 +306,7 @@ outfit "Overcharged Laser Turret"
 		"inaccuracy" 5.5
 		"velocity" 490
 		"lifetime" 1
-		"turret turn" 3.5
+		"turret turn" 1.7
 		"burst count" 4
 		"burst reload" 1
 		"reload" 7

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -66,7 +66,7 @@ outfit "Sunbeam Turret"
 		sound "sunbeam"
 		"hit effect" "sunbeam impact"
 		"inaccuracy" .2
-		"turret turn" 1.3
+		"turret turn" 1.1
 		"velocity" 540
 		"lifetime" 1
 		"reload" 1
@@ -96,7 +96,7 @@ outfit "Dual Sunbeam Turret"
 		sound "sunbeam"
 		"hit effect" "sunbeam impact" 2
 		"inaccuracy" .2
-		"turret turn" 1.0
+		"turret turn" 0.7
 		"velocity" 540
 		"lifetime" 1
 		"reload" 1
@@ -171,7 +171,7 @@ outfit "Moonbeam Turret"
 		"fire effect" "moonbeam fleck"
 		"hit effect" "moonbeam impact"
 		"inaccuracy" 2.0
-		"turret turn" 3.6
+		"turret turn" 1.3
 		"velocity" 490
 		"lifetime" 1
 		# A full cycle is 36 frames. Beam is active 83% of the time.

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -37,6 +37,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Port.h"
 #include "Preferences.h"
 #include "Random.h"
+#include "RoutePlan.h"
 #include "Ship.h"
 #include "ship/ShipAICache.h"
 #include "ShipEvent.h"
@@ -263,30 +264,44 @@ namespace {
 
 	// Determine if the ship with the given travel plan should refuel in
 	// its current system, or if it should keep traveling.
-	bool ShouldRefuel(const Ship &ship, const DistanceMap &route, double fuelCapacity = 0.)
+	bool ShouldRefuel(const Ship &ship, const RoutePlan &route)
 	{
-		if(!fuelCapacity)
-			fuelCapacity = ship.Attributes().Get("fuel capacity");
-
-		const System *from = ship.GetSystem();
-		const bool systemHasFuel = from->HasFuelFor(ship) && fuelCapacity;
-		// If there is no fuel capacity in this ship, no fuel in this
-		// system, if it is fully fueled, or its drive doesn't require
-		// fuel, then it should not refuel before traveling.
-		if(!systemHasFuel || ship.Fuel() == 1. || !ship.JumpNavigation().JumpFuel())
+		// If we can't get to the destination --- no reason to refuel.
+		// (though AI may choose to elsewhere)
+		if(!route.HasRoute())
 			return false;
 
-		// Calculate the fuel needed to reach the next system with fuel.
-		double fuel = fuelCapacity * ship.Fuel();
-		const System *to = route.Route(from);
-		while(to && !to->HasFuelFor(ship))
-			to = route.Route(to);
+		// If the ship is full, no refuel.
+		if(ship.Fuel() == 1.)
+			return false;
 
-		// The returned system from Route is nullptr when the route is
-		// "complete." If 'to' is nullptr here, then there are no fuel
-		// stops between the current system (which has fuel) and the
-		// desired endpoint system - refuel only if needed.
-		return fuel < route.RequiredFuel(from, (to ? to : route.End()));
+		// If the ship has nowhere to refuel, no refuel.
+		const System *from = ship.GetSystem();
+		if(!from->HasFuelFor(ship))
+			return false;
+
+		// If the ship doesn't have fuel, no refuel.
+		double fuelCapacity = ship.Attributes().Get("fuel capacity");
+		if(!fuelCapacity)
+			return false;
+
+		// If the ship has no drive (or doesn't require fuel), no refuel.
+		if(!ship.JumpNavigation().JumpFuel())
+			return false;
+
+		// Now we know it could refuel. But it could also jump along the route
+		// and refuel later. Calculate if it can reach the next refuel.
+		double fuel = fuelCapacity * ship.Fuel();
+		const vector<pair<const System *, int>> costs = route.FuelCosts();
+		for(auto it = costs.rbegin(); it != costs.rend(); ++it)
+		{
+			// If the next system with fuel is outside the range of this ship, should refuel.
+			if(it->first->HasFuelFor(ship))
+				return fuel < it->second;
+		}
+
+		// If no system on the way has fuel, refuel if needed to get to the destination.
+		return fuel < route.RequiredFuel();
 	}
 
 	// The health remaining before becoming disabled, at which fighters and
@@ -2223,40 +2238,38 @@ bool AI::CanRefuel(const Ship &ship, const StellarObject *target)
 // If the ship is an escort it will only use routes known to the player.
 void AI::SelectRoute(Ship &ship, const System *targetSystem) const
 {
-		const System *from = ship.GetSystem();
-		if(from == targetSystem || !targetSystem)
-			return;
-		const DistanceMap route(ship, targetSystem, ship.IsYours() ? &player : nullptr);
-		const bool needsRefuel = ShouldRefuel(ship, route);
-		const System *to = route.Route(from);
-		// The destination may be accessible by both jump and wormhole.
-		// Prefer wormhole travel in these cases, to conserve fuel. Must
-		// check accessibility as DistanceMap may only see the jump path.
-		if(to && !needsRefuel)
-			for(const StellarObject &object : from->Objects())
-			{
-				if(!object.HasSprite() || !object.HasValidPlanet())
-					continue;
-
-				const Planet &planet = *object.GetPlanet();
-				if(planet.IsWormhole() && planet.IsAccessible(&ship)
-						&& &planet.GetWormhole()->WormholeDestination(*from) == to)
-				{
-					ship.SetTargetStellar(&object);
-					ship.SetTargetSystem(nullptr);
-					return;
-				}
-			}
-		else if(needsRefuel)
+	const System *from = ship.GetSystem();
+	if(from == targetSystem || !targetSystem)
+		return;
+	RoutePlan route(ship, *targetSystem, ship.IsYours() ? &player : nullptr);
+	if(ShouldRefuel(ship, route))
+	{
+		// There is at least one planet that can refuel the ship.
+		ship.SetTargetStellar(AI::FindLandingLocation(ship));
+		return;
+	}
+	const System *nextSystem = route.FirstStep();
+	// The destination may be accessible by both jump and wormhole.
+	// Prefer wormhole travel in these cases, to conserve fuel.
+	if(nextSystem)
+		for(const StellarObject &object : from->Objects())
 		{
-			// There is at least one planet that can refuel the ship.
-			ship.SetTargetStellar(AI::FindLandingLocation(ship));
-			return;
+			if(!object.HasSprite() || !object.HasValidPlanet())
+				continue;
+
+			const Planet &planet = *object.GetPlanet();
+			if(planet.IsWormhole() && planet.IsAccessible(&ship)
+				&& &planet.GetWormhole()->WormholeDestination(*from) == nextSystem)
+			{
+				ship.SetTargetStellar(&object);
+				ship.SetTargetSystem(nullptr);
+				return;
+			}
 		}
-		// Either there is no viable wormhole route to this system, or
-		// the target system cannot be reached.
-		ship.SetTargetSystem(to);
-		ship.SetTargetStellar(nullptr);
+	// Either there is no viable wormhole route to this system, or
+	// the target system cannot be reached.
+	ship.SetTargetSystem(nextSystem);
+	ship.SetTargetStellar(nullptr);
 }
 
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -265,6 +265,10 @@ target_sources(EndlessSkyLib PRIVATE
 	RenderBuffer.h
 	RingShader.cpp
 	RingShader.h
+	RouteEdge.cpp
+	RouteEdge.h
+	RoutePlan.cpp
+	RoutePlan.h
 	Sale.h
 	SavedGame.cpp
 	SavedGame.h

--- a/source/CoreStartData.cpp
+++ b/source/CoreStartData.cpp
@@ -69,18 +69,18 @@ Date CoreStartData::GetDate() const
 
 const Planet &CoreStartData::GetPlanet() const
 {
-	return planet ? *planet : *GameData::Planets().Get("New Boston");
+	return (planet && planet->IsValid()) ? *planet : *GameData::Planets().Get("New Boston");
 }
 
 
 
 const System &CoreStartData::GetSystem() const
 {
-	if(system)
+	if(system && system->IsValid())
 		return *system;
 	const System *planetSystem = GetPlanet().GetSystem();
 
-	return planetSystem ? *planetSystem : *GameData::Systems().Get("Rutilicus");
+	return (planetSystem && planetSystem->IsValid()) ? *planetSystem : *GameData::Systems().Get("Rutilicus");
 }
 
 

--- a/source/DistanceMap.cpp
+++ b/source/DistanceMap.cpp
@@ -27,11 +27,11 @@ using namespace std;
 
 
 
-// Find paths to the given system. If the given maximum count is above zero,
+// Find paths from the given system. If the given maximum count is above zero,
 // it is a limit on how many systems should be returned. If it is below zero
 // it specifies the maximum distance away that paths should be found.
-DistanceMap::DistanceMap(const System *center, int maxCount, int maxDistance)
-	: DistanceMap(center, WormholeStrategy::NONE, false, maxCount, maxDistance)
+DistanceMap::DistanceMap(const System *center, int maxSystems, int maxDays)
+	: DistanceMap(center, WormholeStrategy::NONE, false, maxSystems, maxDays)
 {
 }
 
@@ -40,37 +40,37 @@ DistanceMap::DistanceMap(const System *center, int maxCount, int maxDistance)
 // Constructor that allows configuring the use of wormholes and jump drive travel.
 // Since no ship instance is available, we use the base game's default fuel for jump travel.
 DistanceMap::DistanceMap(const System *center, WormholeStrategy wormholeStrategy,
-		bool useJumpDrive, int maxCount, int maxDistance)
-	: center(center), wormholeStrategy(wormholeStrategy), maxCount(maxCount),
-			maxDistance(maxDistance), jumpFuel(useJumpDrive ? 200 : 0), jumpRange(useJumpDrive ? 100. : 0.)
+		bool useJumpDrive, int maxSystems, int maxDays)
+	: center(center), maxSystems(maxSystems), maxDays(maxDays), wormholeStrategy(wormholeStrategy),
+			jumpFuel(useJumpDrive ? 200 : 0), jumpRange(useJumpDrive ? 100. : 0.)
 {
 	Init();
 }
 
 
 
-// If a player is given, the map will only use hyperspace paths known to the
-// player; that is, one end of the path has been visited. Also, if the
-// player's flagship has a jump drive, the jumps will be make use of it.
+// Constructor that uses PlayerInfo to determine the path.
+// If no center system is given, the map will start from the player's system.
+// Pathfinding will only use hyperspace paths known to the player; that is,
+// one end of the path has been visited. Also, if the ship has a jump drive
+// or wormhole access, the route will make use of it.
 DistanceMap::DistanceMap(const PlayerInfo &player, const System *center)
 	: player(&player)
 {
-	if(!player.Flagship())
+	const Ship *flagship = player.Flagship();
+
+	if(!flagship)
 		return;
 
-	if(!center)
-	{
-		if(player.Flagship()->IsEnteringHyperspace())
-			center = player.Flagship()->GetTargetSystem();
-		else
-			center = player.Flagship()->GetSystem();
-	}
-	if(!center)
-		return;
-	else
+	if(center)
 		this->center = center;
+	else if(flagship->IsEnteringHyperspace())
+		this->center = flagship->GetTargetSystem();
+	else
+		this->center = flagship->GetSystem();
 
-	Init(player.Flagship());
+
+	Init(flagship);
 }
 
 
@@ -80,39 +80,38 @@ DistanceMap::DistanceMap(const PlayerInfo &player, const System *center)
 // pathfinding will stop once a path to the destination is found.
 // If a player is given, the path will only include systems that the
 // player has visited.
-DistanceMap::DistanceMap(const Ship &ship, const System *destination, const PlayerInfo *player)
-	: player(player), source(ship.GetSystem()), center(destination)
+DistanceMap::DistanceMap(const System &center, const System &destination, const PlayerInfo *player)
+	: player(player), center(&center), destination(&destination)
 {
-	if(!source || !destination)
-		return;
+	if(player)
+		Init(player->Flagship());
+	else
+		Init();
+}
 
+
+
+DistanceMap::DistanceMap(const Ship &ship, const System &destination, const PlayerInfo *player)
+	: player(player), center(ship.GetSystem()), destination(&destination)
+{
 	Init(&ship);
 }
 
 
 
-// Find out if the given system is reachable.
-bool DistanceMap::HasRoute(const System *system) const
+// Find out if the given system is reachable
+bool DistanceMap::HasRoute(const System &target) const
 {
-	return route.contains(system);
+	return route.contains(&target);
 }
 
 
 
 // Find out how many days away the given system is.
-int DistanceMap::Days(const System *system) const
+int DistanceMap::Days(const System &target) const
 {
-	auto it = route.find(system);
+	auto it = route.find(&target);
 	return (it == route.end() ? -1 : it->second.days);
-}
-
-
-
-// Starting in the given system, what is the next system along the route?
-const System *DistanceMap::Route(const System *system) const
-{
-	auto it = route.find(system);
-	return (it == route.end() ? nullptr : it->second.next);
 }
 
 
@@ -128,44 +127,20 @@ set<const System *> DistanceMap::Systems() const
 
 
 
-// Return the destination system - the 'center' system.
-const System *DistanceMap::End() const
+// Get the planned route from center to this system.
+vector<const System *> DistanceMap::Plan(const System &target) const
 {
-	return center;
-}
+	vector<const System *> plan;
+	if(!HasRoute(target))
+		return plan;
 
-
-
-int DistanceMap::RequiredFuel(const System *system1, const System *system2) const
-{
-	auto it1 = route.find(system1);
-	auto it2 = route.find(system2);
-	if(it1 == route.end() || it2 == route.end())
-		return -1;
-	return abs(it1->second.fuel - it2->second.fuel);
-}
-
-
-
-DistanceMap::Edge::Edge(const System *system)
-	: next(system)
-{
-}
-
-
-
-// Sorting operator to prioritize the "best" edges. The priority queue
-// returns the "largest" item, so this should return true if this item
-// is lower priority than the given item.
-bool DistanceMap::Edge::operator<(const Edge &other) const
-{
-	if(fuel != other.fuel)
-		return (fuel > other.fuel);
-
-	if(days != other.days)
-		return (days > other.days);
-
-	return (danger > other.danger);
+	const System *nextStep = &target;
+	while(nextStep != center)
+	{
+		plan.push_back(nextStep);
+		nextStep = route.at(nextStep).prev;
+	}
+	return plan;
 }
 
 
@@ -175,19 +150,23 @@ bool DistanceMap::Edge::operator<(const Edge &other) const
 // source system or the maximum count is reached.
 void DistanceMap::Init(const Ship *ship)
 {
-	if(!center || (ship && ship->IsRestrictedFrom(*center)))
+	if(!center || (ship && ship->IsRestrictedFrom(*center)) || center == destination)
 		return;
 
-	route[center] = Edge();
-	if(!maxDistance)
+	// To get to the starting point, there is no previous system,
+	// and it takes no fuel or days.
+	route[center] = RouteEdge();
+	if(!maxDays)
 		return;
 
-	// Check what travel capabilities this ship has. If no ship is given, assume
-	// hyperdrive capability and no jump drive.
+	// Check what travel capabilities this ship has. If no ship is given, the
+	// DistanceMap class defaults assume hyperdrive capability only.
 	if(ship)
 	{
 		this->ship = ship;
 		hyperspaceFuel = ship->JumpNavigation().HyperdriveFuel();
+		// Todo: consider outfit "jump distance" at each link to find if more fuel is needed
+		// by a second jump drive outfit with more range and cost via JumpDriveFuel(to).
 		jumpFuel = ship->JumpNavigation().JumpDriveFuel();
 		jumpRange = ship->JumpNavigation().JumpRange();
 		// If hyperjumps and non-hyper jumps cost the same amount, or non-hyper jumps are always cheaper,
@@ -216,39 +195,52 @@ void DistanceMap::Init(const Ship *ship)
 	// choose the one with the fewest jumps (i.e. using jump drive rather than
 	// hyperdrive). If multiple routes have the same fuel and the same number of
 	// jumps, break the tie by using how "dangerous" the route is.
-	edges.emplace(center);
-	while(maxCount && !edges.empty())
-	{
-		Edge top = edges.top();
-		edges.pop();
 
-		// Source is only defined when given a ship and a destination system.
-		// Once we have a route between them, stop searching for more routes.
-		if(top.next == source)
+	// Add this fake edge "from center" so it's the first popped value.
+	edgesTodo.emplace(center);
+	// Find all edges from that route, add better routes to the map, and continue.
+	while(maxSystems && !edgesTodo.empty())
+	{
+		// Use the best known route to build upon and create the next set
+		// of candidate edges. RouteEdges are inserted with 'prev' assigned, but the
+		// other values are a step behind. Here we copy and update them:
+		// For each system 'X' reachable from 'prev', the edge's fuel/days/danger
+		// are built upon to determine if this new edge from 'prev' to 'X' is
+		// the best. If so, it's added as route[X], and a copy is added to
+		// edgesTodo to process later.
+		RouteEdge nextEdge = edgesTodo.top();
+		edgesTodo.pop();
+
+		const System *currentSystem = nextEdge.prev;
+
+		// If a destination is given, stop searching once we have the best route.
+		if(currentSystem == destination)
 			break;
-		// Increment the danger and the travel time to include this system. The
-		// fuel cost will be incremented later, because it depends on what type
-		// of travel is being done.
-		top.danger += top.next->Danger();
-		++top.days;
+
+		// Increment the danger to include this system.
+		// Don't need to worry about the danger for the next system because
+		// if you're going there, all routes would include that same danger.
+		// (It is slightly redundant that this includes the danger of the
+		//  starting system instead, but the code is simpler this way.)
+		nextEdge.danger += currentSystem->Danger();
+
+		// Increment the travel time to include the next system. The fuel cost will be
+		// incremented later, because it depends on what type of travel is being done.
+		++nextEdge.days;
 
 		// Check for wormholes (which cost zero fuel). Wormhole travel should
 		// not be included in Local Maps or mission itineraries.
 		if(wormholeStrategy != WormholeStrategy::NONE)
-			for(const StellarObject &object : top.next->Objects())
+			for(const StellarObject &object : currentSystem->Objects())
 				if(object.HasSprite() && object.HasValidPlanet() && object.GetPlanet()->IsWormhole()
 					&& (object.GetPlanet()->IsUnrestricted() || wormholeStrategy == WormholeStrategy::ALL))
 				{
-					// If we're seeking a path toward a "source," travel through
-					// wormholes in the reverse of the normal direction.
-					const System &link = source ?
-						object.GetPlanet()->GetWormhole()->WormholeSource(*top.next) :
-						object.GetPlanet()->GetWormhole()->WormholeDestination(*top.next);
-					if(HasBetter(link, top))
+					const System &link = object.GetPlanet()->GetWormhole()->WormholeDestination(*currentSystem);
+					if(HasBetter(link, nextEdge))
 						continue;
 
 					// In order to plan travel through a wormhole, it must be
-					// "accessible" to your flagship, and you must have visited
+					// "accessible" to the ship, and you must have visited
 					// the wormhole and both endpoint systems must be viewable.
 					// (If this is a multi-stop wormhole, you may know about
 					// some paths that it takes but not others.)
@@ -257,36 +249,42 @@ void DistanceMap::Init(const Ship *ship)
 						continue;
 					if(player && !player->HasVisited(*object.GetPlanet()))
 						continue;
-					if(player && !(player->CanView(*top.next) && player->CanView(link)))
+					if(player && !(player->CanView(*currentSystem) && player->CanView(link)))
 						continue;
 
-					Add(link, top);
+					Add(link, nextEdge);
+					// Bail out if the maximum number of systems is reached.
+					if(!--maxSystems)
+						break;
 				}
 
 		// Bail out if the maximum number of systems is reached.
-		if(hyperspaceFuel && !Propagate(top, false))
+		if(hyperspaceFuel && !Propagate(nextEdge, false))
 			break;
-		if(jumpFuel && !Propagate(top, true))
+		if(jumpFuel && !Propagate(nextEdge, true))
 			break;
 	}
 }
 
 
 
-// Add the given links to the map. Return false if an end condition is hit.
-bool DistanceMap::Propagate(Edge edge, bool useJump)
+// Add the given links to the map, if better. Return false if max systems has been reached.
+bool DistanceMap::Propagate(RouteEdge nextEdge, bool useJump)
 {
-	edge.fuel += (useJump ? jumpFuel : hyperspaceFuel);
-	for(const System *link : (useJump ? edge.next->JumpNeighbors(jumpRange) : edge.next->Links()))
+	const System *currentSystem = nextEdge.prev;
+
+	// nextEdge is a copy to be used for this jump type, so build upon its fields.
+	nextEdge.fuel += (useJump ? jumpFuel : hyperspaceFuel);
+	for(const System *link : (useJump ? currentSystem->JumpNeighbors(jumpRange) : currentSystem->Links()))
 	{
 		// Find out whether we already have a better path to this system, and
 		// check whether this link can be traveled. If this route is being
 		// selected by the player, they are constrained to known routes.
-		if(HasBetter(*link, edge) || !CheckLink(*edge.next, *link, useJump))
+		if(HasBetter(*link, nextEdge) || !CheckLink(*currentSystem, *link, useJump))
 			continue;
 
-		Add(*link, edge);
-		if(!--maxCount)
+		Add(*link, nextEdge);
+		if(!--maxSystems)
 			return false;
 	}
 	return true;
@@ -295,7 +293,7 @@ bool DistanceMap::Propagate(Edge edge, bool useJump)
 
 
 // Check if we already have a better path to the given system.
-bool DistanceMap::HasBetter(const System &to, const Edge &edge)
+bool DistanceMap::HasBetter(const System &to, const RouteEdge &edge)
 {
 	auto it = route.find(&to);
 	return (it != route.end() && !(it->second < edge));
@@ -304,14 +302,17 @@ bool DistanceMap::HasBetter(const System &to, const Edge &edge)
 
 
 // Add the given path to the record.
-void DistanceMap::Add(const System &to, Edge edge)
+void DistanceMap::Add(const System &to, RouteEdge edge)
 {
 	// This is the best path we have found so far to this system, but it is
 	// conceivable that a better one will be found.
 	route[&to] = edge;
-	edge.next = &to;
-	if(maxDistance < 0 || edge.days < maxDistance)
-		edges.emplace(edge);
+
+	// Start building upon this edge and enqueue - this copy of edge
+	// is in an incomplete state and needs to be dequeued and worked on.
+	edge.prev = &to;
+	if(maxDays < 0 || edge.days < maxDays)
+		edgesTodo.emplace(edge);
 }
 
 

--- a/source/DistanceMap.h
+++ b/source/DistanceMap.h
@@ -15,12 +15,14 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #pragma once
 
+#include "RouteEdge.h"
 #include "WormholeStrategy.h"
 
 #include <map>
 #include <queue>
 #include <set>
 #include <utility>
+#include <vector>
 
 class PlayerInfo;
 class Ship;
@@ -28,77 +30,58 @@ class System;
 
 
 
-// This is a map of how many hyperspace jumps it takes to get to other systems
-// from the given "center" system. Ships with a hyperdrive travel using the
-// "links" between systems. Ships with jump drives can make use of those links,
-// but can also travel to any of a system's "neighbors." A distance map can also
-// be used to calculate the shortest route between two systems.
+// This is a map of shortest routes to all other systems from the given "center"
+// system. It also tracks how many days and fuel it takes to get there. Ships with
+// a hyperdrive travel using the "links" between systems. Ships with jump drives
+// can make use of those links, but can also travel to any system that's close by.
+// Wormholes can also be used by players or ships.
 class DistanceMap {
 public:
-	// Find paths to the given system. The optional arguments put a limit on how
-	// many systems will be returned and how far away they are allowed to be.
-	explicit DistanceMap(const System *center, int maxCount = -1, int maxDistance = -1);
-	// Find paths to the given system, potentially using wormholes, a jump drive, or both.
+	// Find paths branching out from the given system. The optional arguments put
+	// a limit on how many systems will be returned (e.g. buying a local map) and
+	// a limit on how many jumps away they can be (e.g. a valid mission location).
+	explicit DistanceMap(const System *center, int maxSystems = -1, int maxDays = -1);
+	// If a player is given with no center, the map will start from the player's system.
+	// Pathfinding will only use hyperspace paths known to the player; that is,
+	// one end of the path has been visited. Also, if the ship has a jump drive
+	// or wormhole access, the route will make use of it.
+	explicit DistanceMap(const PlayerInfo &player, const System *center = nullptr);
+	// Find paths from the given system, potentially using wormholes, a jump drive, or both.
 	// Optional arguments are as above.
 	explicit DistanceMap(const System *center, WormholeStrategy wormholeStrategy,
-			bool useJumpDrive, int maxCount = -1, int maxDistance = -1);
-	// If a player is given, the map will only use hyperspace paths known to the
-	// player; that is, one end of the path has been visited. Also, if the
-	// player's flagship has a jump drive, the jumps will be make use of it.
-	explicit DistanceMap(const PlayerInfo &player, const System *center = nullptr);
-	// Calculate the path for the given ship to get to the given system. The
-	// ship will use a jump drive or hyperdrive depending on what it has. The
-	// pathfinding will stop once a path to the destination is found.
-	// If a player is given, the path will only include systems that the
-	// player has visited.
-	DistanceMap(const Ship &ship, const System *destination, const PlayerInfo *player = nullptr);
+			bool useJumpDrive, int maxSystems = -1, int maxDays = -1);
 
 	// Find out if the given system is reachable.
-	bool HasRoute(const System *system) const;
+	bool HasRoute(const System &system) const;
 	// Find out how many days away the given system is.
-	int Days(const System *system) const;
-	// Starting in the given system, what is the next system along the route?
-	const System *Route(const System *system) const;
-
+	int Days(const System &system) const;
+	// Get the planned route from center to this system.
+	std::vector<const System *> Plan(const System &system) const;
 	// Get a set containing all the systems.
 	std::set<const System *> Systems() const;
-	// Get the end of the route.
-	const System *End() const;
-
-	// How much fuel is needed to travel between two systems.
-	int RequiredFuel(const System *system1, const System *system2) const;
 
 
 private:
-	// For each system, track how much fuel it will take to get there, how many
-	// days, how much danger you will pass through, and where you will go next.
-	class Edge {
-	public:
-		explicit Edge(const System *system = nullptr);
+	// To use DistanceMap with a destination, you must use RoutePlan as a wrapper,
+	// which uses these private constructors. The pathfinding will stop once it
+	// finds the best path to the destination. If a player is given, the path will
+	// only include systems that the player has visited.
+	explicit DistanceMap(const System &center, const System &destination, const PlayerInfo *player = nullptr);
 
-		// Sorting operator to prioritize the "best" edges. The priority queue
-		// returns the "largest" item, so this should return true if this item
-		// is lower priority than the given item.
-		bool operator<(const Edge &other) const;
+	// Calculate the path for the given ship to get to the given system. The
+	// ship will use a jump drive or hyperdrive depending on what it has.
+	explicit DistanceMap(const Ship &ship, const System &destination, const PlayerInfo *player = nullptr);
 
-		const System *next = nullptr;
-		int fuel = 0;
-		int days = 0;
-		double danger = 0.;
-	};
-
-
-private:
 	// Depending on the capabilities of the given ship, use hyperspace paths,
 	// jump drive paths, or both to find the shortest route. Bail out if the
-	// source system or the maximum count is reached.
+	// destination system or the maximum count is reached.
 	void Init(const Ship *ship = nullptr);
 	// Add the given links to the map. Return false if an end condition is hit.
-	bool Propagate(Edge edge, bool useJump);
+	bool Propagate(RouteEdge edge, bool useJump);
 	// Check if we already have a better path to the given system.
-	bool HasBetter(const System &to, const Edge &edge);
+	bool HasBetter(const System &to, const RouteEdge &edge);
 	// Add the given path to the record.
-	void Add(const System &to, Edge edge);
+	void Add(const System &to, RouteEdge edge);
 	// Check whether the given link is travelable. If no player was given in the
 	// constructor then this is always true; otherwise, the player must know
 	// that the given link exists.
@@ -106,20 +89,29 @@ private:
 
 
 private:
-	std::map<const System *, Edge> route;
+	// Final route, each Edge pointing to the previous step along the route.
+	std::map<const System *, RouteEdge> route;
 
 	// Variables only used during construction:
-	std::priority_queue<Edge> edges;
+	// 'edgesTodo' holds unfinished candidate Edges - Only the 'prev' value
+	// is up-to-date. Other values are one step behind, awaiting an update.
+	// The top() value is the best route among uncertain systems. Once
+	// popped, that's the best route to that system - and then adjacent links
+	// from that system are processed, which will build upon the popped Edge.
+	std::priority_queue<RouteEdge> edgesTodo;
 	const PlayerInfo *player = nullptr;
-	const System *source = nullptr;
 	const System *center = nullptr;
+	int maxSystems = -1;
+	int maxDays = -1;
+	const System *destination = nullptr;
 	WormholeStrategy wormholeStrategy = WormholeStrategy::ALL;
-	int maxCount = -1;
-	int maxDistance = -1;
 	// How much fuel is used for travel. If either value is zero, it means that
 	// the ship does not have that type of drive.
+	// Defaults are set for hyperlane usage only. Using a ship overrides these.
 	int hyperspaceFuel = 100;
 	int jumpFuel = 0;
 	double jumpRange = 0.;
 	const Ship *ship = nullptr;
+
+	friend class RoutePlan;
 };

--- a/source/LocationFilter.cpp
+++ b/source/LocationFilter.cpp
@@ -104,7 +104,7 @@ namespace {
 			);
 		}
 		// If the distance is greater than the maximum, this is not a match.
-		int d = distance.Days(system);
+		int d = distance.Days(*system);
 		return (d > maximum) ? -1 : d;
 	}
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -798,11 +798,13 @@ void MapDetailPanel::DrawInfo()
 			else
 			{
 				value -= localValue;
-				price += "(";
+				if(Preferences::Has("Show parenthesis"))
+					price += "(";
 				if(value > 0)
 					price += '+';
 				price += to_string(value);
-				price += ")";
+				if(Preferences::Has("Show parenthesis"))
+					price += ")";
 			}
 		}
 		else

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -41,6 +41,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Politics.h"
 #include "Preferences.h"
 #include "RingShader.h"
+#include "RoutePlan.h"
 #include "Screen.h"
 #include "Ship.h"
 #include "ShipJumpNavigation.h"
@@ -165,17 +166,17 @@ namespace {
 				if(Preferences::Has("Deadline blink by distance"))
 				{
 					DistanceMap distance(player, player.GetSystem());
-					if(distance.HasRoute(mission.Destination()->GetSystem()))
+					if(distance.HasRoute(*mission.Destination()->GetSystem()))
 					{
 						set<const System *> toVisit;
 						for(const Planet *stopover : mission.Stopovers())
 						{
-							if(distance.HasRoute(stopover->GetSystem()))
+							if(distance.HasRoute(*stopover->GetSystem()))
 								toVisit.insert(stopover->GetSystem());
 							--daysLeft;
 						}
 						for(const System *waypoint : mission.Waypoints())
-							if(distance.HasRoute(waypoint))
+							if(distance.HasRoute(*waypoint))
 								toVisit.insert(waypoint);
 
 						int systemCount = toVisit.size();
@@ -184,16 +185,16 @@ namespace {
 							const System *closest;
 							int minimalDist = numeric_limits<int>::max();
 							for(const System *sys : toVisit)
-								if(distance.Days(sys) < minimalDist)
+								if(distance.Days(*sys) < minimalDist)
 								{
 									closest = sys;
-									minimalDist = distance.Days(sys);
+									minimalDist = distance.Days(*sys);
 								}
-							daysLeft -= distance.Days(closest);
+							daysLeft -= distance.Days(*closest);
 							distance = DistanceMap(player, closest);
 							toVisit.erase(closest);
 						}
-						daysLeft -= distance.Days(mission.Destination()->GetSystem());
+						daysLeft -= distance.Days(*mission.Destination()->GetSystem());
 					}
 				}
 				int blinkFactor = min(6, max(1, daysLeft));
@@ -406,7 +407,7 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 
 	// Draw a warning if the selected system is not routable.
 
-	if(selectedSystem != &playerSystem && !distance.HasRoute(selectedSystem))
+	if(selectedSystem != &playerSystem && !distance.HasRoute(*selectedSystem))
 	{
 		static const string UNAVAILABLE = "You have no available route to this system.";
 		static const string UNKNOWN = "You have not yet mapped a route to this system.";
@@ -797,30 +798,23 @@ void MapPanel::Select(const System *system)
 	}
 	else if(shift)
 	{
-		DistanceMap localDistance(player, plan.front());
-		if(localDistance.Days(system) <= 0)
+		const System *planEnd = plan.front();
+		if(system == planEnd)
 			return;
 
-		auto it = plan.begin();
-		while(system != *it)
-		{
-			it = ++plan.insert(it, system);
-			system = localDistance.Route(system);
-		}
+		RoutePlan addedRoute(*planEnd, *system, &player);
+		if(!addedRoute.HasRoute())
+			return;
+
+		vector<const System *> newPlan = addedRoute.Plan();
+		plan.insert(plan.begin(), newPlan.begin(), newPlan.end());
 	}
-	else if(distance.Days(system) > 0)
+	else if(distance.HasRoute(*system))
 	{
-		plan.clear();
 		if(!isJumping)
 			flagship->SetTargetSystem(nullptr);
 
-		while(system != source)
-		{
-			plan.push_back(system);
-			system = distance.Route(system);
-		}
-		if(isJumping)
-			plan.push_back(source);
+		plan = distance.Plan(*system);
 	}
 
 	// Reset the travel destination if the final system in the travel plan has changed.
@@ -1234,8 +1228,8 @@ void MapPanel::DrawSelectedSystem()
 	auto it = find(plan.begin(), plan.end(), selectedSystem);
 	if(it != plan.end())
 		jumps = plan.end() - it;
-	else if(distance.HasRoute(selectedSystem))
-		jumps = distance.Days(selectedSystem);
+	else if(distance.HasRoute(*selectedSystem))
+		jumps = distance.Days(*selectedSystem);
 
 	if(jumps == 1)
 		text += " (1 jump away)";

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -1584,12 +1584,12 @@ int Mission::CalculateJumps(const System *sourceSystem)
 				distanceCalcSettings.AssumesJumpDrive());
 		auto it = destinations.begin();
 		auto bestIt = it;
-		int bestDays = distance.Days(*bestIt);
+		int bestDays = distance.Days(**bestIt);
 		if(bestDays < 0)
 			bestDays = numeric_limits<int>::max();
 		for(++it; it != destinations.end(); ++it)
 		{
-			int days = distance.Days(*it);
+			int days = distance.Days(**it);
 			if(days >= 0 && days < bestDays)
 			{
 				bestIt = it;
@@ -1606,7 +1606,7 @@ int Mission::CalculateJumps(const System *sourceSystem)
 			distanceCalcSettings.WormholeStrat(),
 			distanceCalcSettings.AssumesJumpDrive());
 	// If currently unreachable, this system adds -1 to the deadline, to match previous behavior.
-	expectedJumps += distance.Days(destination->GetSystem());
+	expectedJumps += distance.Days(*destination->GetSystem());
 
 	return expectedJumps;
 }

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -216,11 +216,11 @@ void MissionPanel::Draw()
 	const Color &routeColor = *colors.Get("mission route");
 	const Ship *flagship = player.Flagship();
 	const double jumpRange = flagship ? flagship->JumpNavigation().JumpRange() : 0.;
-	const System *previous = nullptr;
-	const System *next = selectedSystem;
-	for(; distance.Days(next) > 0; next = previous)
+	const System *previous = player.GetSystem();
+	const vector<const System *> plan = distance.Plan(*selectedSystem);
+	for(auto it = plan.rbegin(); it != plan.rend(); ++it)
 	{
-		previous = distance.Route(next);
+		const System *next = *it;
 
 		bool isJump, isWormhole, isMappable;
 		if(!GetTravelInfo(previous, next, jumpRange, isJump, isWormhole, isMappable, nullptr))
@@ -239,6 +239,8 @@ void MissionPanel::Draw()
 			LineShader::DrawDashed(from, to, unit, 3.f, routeColor, 11., 4.);
 		else
 			LineShader::Draw(from, to, 3.f, routeColor);
+
+		previous = next;
 	}
 
 	const Color &availableColor = *colors.Get("available back");

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3850,9 +3850,9 @@ void PlayerInfo::RegisterDerivedConditions()
 			return -1;
 
 		auto distanceMap = DistanceMap(origin);
-		if(!distanceMap.HasRoute(destination))
+		if(!distanceMap.HasRoute(*destination))
 			return -1;
-		return distanceMap.Days(destination);
+		return distanceMap.Days(*destination);
 	};
 
 	auto &&hyperjumpsToSystemProvider = conditions.GetProviderPrefixed("hyperjumps to system: ");

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -693,7 +693,8 @@ void PreferencesPanel::DrawSettings()
 		"Interrupt fast-forward",
 		"Landing zoom",
 		SCROLL_SPEED,
-		DATE_FORMAT
+		DATE_FORMAT,
+		"Show parenthesis"
 	};
 
 	bool isCategory = true;

--- a/source/RouteEdge.cpp
+++ b/source/RouteEdge.cpp
@@ -1,0 +1,39 @@
+/* RouteEdge.cpp
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "RouteEdge.h"
+
+
+
+RouteEdge::RouteEdge(const System *system)
+	: prev(system)
+{
+}
+
+
+
+// Sorting operator to prioritize the "best" edges. The priority queue
+// returns the "largest" item, so this should return true if this item
+// is lower priority than the given item.
+bool RouteEdge::operator<(const RouteEdge &other) const
+{
+	if(fuel != other.fuel)
+		return fuel > other.fuel;
+
+	if(days != other.days)
+		return days > other.days;
+
+	return danger > other.danger;
+}

--- a/source/RouteEdge.h
+++ b/source/RouteEdge.h
@@ -1,0 +1,47 @@
+/* RouteEdge.h
+Copyright (c) 2014 by Michael Zahniser
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+class System;
+
+
+
+// DistanceMap is built using branching paths from 'center' to all systems.
+// The final result, though, is Edges backtracking those paths:
+// Each system has one Edge which points to the previous step along
+// the route to get there, including how much fuel and how many days
+// the total route will take, and how much danger you will pass through.
+// While building the map, some systems have a non-optimal Edge that
+// gets replaced when a better route is found.
+class RouteEdge {
+public:
+	RouteEdge(const System *system = nullptr);
+
+	// Sorting operator to prioritize the "best" edges. The priority queue
+	// returns the "largest" item, so this should return true if this item
+	// is lower priority than the given item.
+	bool operator<(const RouteEdge &other) const;
+
+	// There could be a System *thisSystem, but it would remained unused.
+	const System *prev = nullptr;
+	// Fuel/days needed to get to this system using the route through 'prev'.
+	int fuel = 0;
+	int days = 0;
+	// Danger tracks up to the 'prev' system, not to the this system.
+	// It's used for comparison purposes only. Anyone going to this system
+	// is going to hit its danger anyway, so it doesn't change anything.
+	double danger = 0.;
+};

--- a/source/RoutePlan.cpp
+++ b/source/RoutePlan.cpp
@@ -1,0 +1,115 @@
+/* RoutePlan.cpp
+Copyright (c) 2022 by alextd
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "RoutePlan.h"
+
+#include "DistanceMap.h"
+
+using namespace std;
+
+
+
+// RoutePlan is a wrapper on DistanceMap that uses destination
+RoutePlan::RoutePlan(const System &center, const System &destination, const PlayerInfo *player)
+{
+	Init(DistanceMap(center, destination, player));
+}
+
+
+
+RoutePlan::RoutePlan(const Ship &ship, const System &destination, const PlayerInfo *player)
+{
+	Init(DistanceMap(ship, destination, player));
+}
+
+
+
+void RoutePlan::Init(const DistanceMap &distance)
+{
+	auto it = distance.route.find(distance.destination);
+	if(it == distance.route.end())
+		return;
+
+	hasRoute = true;
+
+	while(it->first != distance.center)
+	{
+		plan.emplace_back(it->first, it->second);
+		it = distance.route.find(it->second.prev);
+	}
+}
+
+
+
+// Find out if the destination is reachable.
+bool RoutePlan::HasRoute() const
+{
+	return hasRoute;
+}
+
+
+
+// Get the first step on the route from center to the destination.
+const System *RoutePlan::FirstStep() const
+{
+	if(!hasRoute)
+		return nullptr;
+
+	return plan.back().first;
+}
+
+
+
+// Find out how many days away the destination is.
+int RoutePlan::Days() const
+{
+	if(!hasRoute)
+		return -1;
+
+	return plan.front().second.days;
+}
+
+
+
+// How much fuel is needed to travel to this system along the route.
+int RoutePlan::RequiredFuel() const
+{
+	if(!hasRoute)
+		return -1;
+
+	return plan.front().second.fuel;
+}
+
+
+
+// Get the list of jumps to take to get to the destination.
+vector<const System *> RoutePlan::Plan() const
+{
+	vector<const System *> steps;
+	for(const auto &it : plan)
+		steps.push_back(it.first);
+	return steps;
+}
+
+
+
+// How much fuel is needed to travel to this system along the route.
+vector<pair<const System *, int>> RoutePlan::FuelCosts() const
+{
+	vector<pair<const System *, int>> steps;
+	for(const auto &it : plan)
+		steps.emplace_back(it.first, it.second.fuel);
+	return steps;
+}

--- a/source/RoutePlan.h
+++ b/source/RoutePlan.h
@@ -1,0 +1,59 @@
+/* RoutePlan.h
+Copyright (c) 2022 by alextd
+
+Endless Sky is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later version.
+
+Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "RouteEdge.h"
+
+#include <vector>
+
+class DistanceMap;
+class PlayerInfo;
+class Ship;
+class System;
+
+
+
+// RoutePlan is a wrapper for DistanceMap that uses a destination
+// and keeps only the route to that system.
+class RoutePlan {
+public:
+	explicit RoutePlan(const System &center, const System &destination, const PlayerInfo *player = nullptr);
+	explicit RoutePlan(const Ship &ship, const System &destination, const PlayerInfo *player = nullptr);
+
+	// Find out if the destination is reachable.
+	bool HasRoute() const;
+	// Get the first step on the route from center to the destination.
+	const System *FirstStep() const;
+	// Find out how many days away the destination is.
+	int Days() const;
+	// How much fuel is needed to travel to this system along the route.
+	int RequiredFuel() const;
+
+	// Get the list of jumps to take to get to the destination.
+	std::vector<const System *> Plan() const;
+	// Get the list of jumps + fuel to take to get to the destination.
+	std::vector<std::pair<const System *, int>> FuelCosts() const;
+
+
+private:
+	void Init(const DistanceMap &distance);
+
+
+private:
+	// The final planned route. plan.front() is the destination.
+	std::vector<std::pair<const System *, RouteEdge>> plan;
+	bool hasRoute = false;
+};

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -507,12 +507,15 @@ void ShipInfoPanel::DrawWeapons(const Rectangle &bounds)
 	auto layout = Layout(static_cast<int>(LABEL_WIDTH), Truncate::BACK);
 	for(const Hardpoint &hardpoint : ship.Weapons())
 	{
-		string name = "[empty]";
+		
+		bool isRight = (hardpoint.GetPoint().X() >= 0.);
+		bool isTurret = hardpoint.IsTurret();
+		string name = "[empty510]";
+		if(isTurret == true)
+			name = "[empty turret mount]";
 		if(hardpoint.GetOutfit())
 			name = hardpoint.GetOutfit()->DisplayName();
 
-		bool isRight = (hardpoint.GetPoint().X() >= 0.);
-		bool isTurret = hardpoint.IsTurret();
 
 		double &y = nextY[isRight][isTurret];
 		double x = centerX + (isRight ? LABEL_DX : -LABEL_DX - LABEL_WIDTH);
@@ -554,7 +557,7 @@ void ShipInfoPanel::DrawWeapons(const Rectangle &bounds)
 	if(draggingIndex >= 0)
 	{
 		const Outfit *outfit = ship.Weapons()[draggingIndex].GetOutfit();
-		string name = outfit ? outfit->DisplayName() : "[empty]";
+		string name = outfit ? outfit->DisplayName() : "[empty559]";
 		Point pos(hoverPoint.X() - .5 * font.Width(name), hoverPoint.Y());
 		font.Draw(name, pos + Point(1., 1.), Color(0., 1.));
 		font.Draw(name, pos, bright);

--- a/source/ShipInfoPanel.cpp
+++ b/source/ShipInfoPanel.cpp
@@ -513,6 +513,12 @@ void ShipInfoPanel::DrawWeapons(const Rectangle &bounds)
 		string name = "[empty510]";
 		if(isTurret == true)
 			name = "[empty turret mount]";
+		bool isGun = hardpoint.IsGun();
+		if(isGun == true)
+			name = "[empty gun port]";
+		bool isPylon = hardpoint.IsPylon();
+		if(isPylon == true)
+			name = "[empty pylon]";
 		if(hardpoint.GetOutfit())
 			name = hardpoint.GetOutfit()->DisplayName();
 


### PR DESCRIPTION
Currently, hardpoints just have a generic `[empty]` label when they are not being used.

This changes the turret hardpoints to have a `[empty turret mount]` label.

Note: Two other spots that apply the empty label have received numbers added to them to facilitate identifying when they show up, but this is not intended to be merged. 

To-do:

- [ ] pylon hardpoint
- [ ] gun hardpoint