### PR TITLE
fix(typo): Endless Sky -> Endless Sky Delta in the "friendly author" phrase

### DIFF
--- a/data/human/hails.txt
+++ b/data/human/hails.txt
@@ -5069,7 +5069,7 @@ phrase "friendly disabled pirate"
 phrase "friendly author"
 	word
 		"This game"
-		"Endless Sky"
+		"Endless Sky Delta"
 	word
 		" is open source. You can "
 	word


### PR DESCRIPTION
**Typo Fix**

`Endless Sky` changed to `Endless Sky Delta` in the phrase `friendly author`.