### PR TITLE
Feat(code): Converting pylon to missile pylon for ease of understanding

### DIFF
--- a/data/_deprecated/deprecated outfits.txt
+++ b/data/_deprecated/deprecated outfits.txt
@@ -450,7 +450,7 @@ outfit "Korath Piercer Launcher"
 	"outfit space" -27
 	"weapon capacity" -27
 	"energy capacity" 50
-	pylon -1
+	"missile pylons" -1
 	"piercer capacity" 31
 	weapon
 		sprite "projectile/piercer"

--- a/data/_deprecated/deprecated outfits.txt
+++ b/data/_deprecated/deprecated outfits.txt
@@ -450,7 +450,7 @@ outfit "Korath Piercer Launcher"
 	"outfit space" -27
 	"weapon capacity" -27
 	"energy capacity" 50
-	"pylon" -1
+	pylon -1
 	"piercer capacity" 31
 	weapon
 		sprite "projectile/piercer"

--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -277,10 +277,10 @@ tip "fuel protection:"
 	`Protection provided against fuel damage. If you add more than one outfit with this attribute, each additional one is less effective: a total value of 1 results in a 1 percent reduction in fuel damage, while a total value of 11 only results in a 10 percent reduction.`
 
 tip "gun ports needed:"
-	`This weapon uses up a gun port. Guns always fire straight forward; turrets fire in the direction of your currently selected target.`
+	`This weapon uses up a gun port. Guns always fire on a specified angle, which is usually forwards.`
 
 tip "gun ports free:"
-	`How many guns this ship can hold. This includes most missiles and secondary weapons that fire straight forward.`
+	`How many guns this ship can hold. This includes all primary weapons that fire in a fixed direction.`
 
 tip "heat dissipation:"
 	`How effectively this ship radiates excess heat.`
@@ -533,6 +533,12 @@ tip "piercing protection:"
 
 tip "piercing resistance:"
 	`Piercing damage resisted on all incoming projectiles, preventing damage from leaking through the shields to the hull.`
+
+tip "pylons needed:"
+	`This weapon uses up a missile pylon. Pylons always fire on a set angle, which is often forward but may be on an angle to provide counter-flanking or counter-pursuit fire.`
+
+tip "missile pylons free:"
+	`How many pylons this ship can hold. This includes all rockets, missiles, torpedoes and similar secondary weapons.`
 
 tip "radar jamming:"
 	`Reduces the ability of radar-guided missiles to track your ship. The more radar jamming is installed, the greater the distance at which missiles can be jammed, and the greater the chance that a jammed missile will fly off in a random direction.`
@@ -829,10 +835,10 @@ tip "turning disruption:"
 	`Accumulated shield interference per second when turning.`
 
 tip "turret mounts needed:"
-	`This weapon can fire in any direction, tracking your currently selected target. It uses up one of your ship's turret mounts.`
+	`This weapon can fire in any direction, tracking your currently selected target or closest enemy ship depending on your preferences. It uses up one of your ship's turret mounts.`
 
 tip "turret mounts free:"
-	`How many turrets can be mounted on this ship. Turrets fire in the direction of the currently selected target, instead of firing straight forward like guns.`
+	`How many turrets can be mounted on this ship. Turrets fire in the direction of the currently selected target, instead of firing straight forward like guns. Some turret mounts may have a limited range of fire.`
 
 tip "weapon capacity needed:"
 	`Tons of weapon space this outfit takes up.`

--- a/data/bunrodea/bunrodea weapons.txt
+++ b/data/bunrodea/bunrodea weapons.txt
@@ -194,7 +194,7 @@ outfit "Swarm Pod"
 	"mass" 5
 	"outfit space" -21
 	"weapon capacity" -21
-	pylon -1
+	"missile pylons" -1
 	"swarm capacity" 400
 	weapon
 		sprite "effect/swarm"

--- a/data/bunrodea/bunrodea weapons.txt
+++ b/data/bunrodea/bunrodea weapons.txt
@@ -194,7 +194,7 @@ outfit "Swarm Pod"
 	"mass" 5
 	"outfit space" -21
 	"weapon capacity" -21
-	"pylon" -1
+	pylon -1
 	"swarm capacity" 400
 	weapon
 		sprite "effect/swarm"

--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -89,7 +89,7 @@ outfit "Finisher Pod"
 	"mass" 16
 	"outfit space" -36
 	"weapon capacity" -36
-	pylon -1
+	"missile pylons" -1
 	"finisher capacity" 40
 	weapon
 		sprite "projectile/finisher activating"
@@ -126,7 +126,7 @@ outfit "Finisher Maegrolain"
 	"mass" 58
 	"outfit space" -88
 	"weapon capacity" -88
-	pylon -1
+	"missile pylons" -1
 	"finisher capacity" 60
 	weapon
 		sprite "projectile/finisher activating"

--- a/data/coalition/coalition weapons.txt
+++ b/data/coalition/coalition weapons.txt
@@ -89,7 +89,7 @@ outfit "Finisher Pod"
 	"mass" 16
 	"outfit space" -36
 	"weapon capacity" -36
-	"pylon" -1
+	pylon -1
 	"finisher capacity" 40
 	weapon
 		sprite "projectile/finisher activating"
@@ -126,7 +126,7 @@ outfit "Finisher Maegrolain"
 	"mass" 58
 	"outfit space" -88
 	"weapon capacity" -88
-	"pylon" -1
+	pylon -1
 	"finisher capacity" 60
 	weapon
 		sprite "projectile/finisher activating"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -338,7 +338,7 @@ outfit "Hai Tracker Pod"
 	"mass" 8
 	"outfit space" -19
 	"weapon capacity" -19
-	pylon -1
+	"missile pylons" -1
 	"tracker capacity" 56
 	weapon
 		sprite "projectile/tracker"

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -338,7 +338,7 @@ outfit "Hai Tracker Pod"
 	"mass" 8
 	"outfit space" -19
 	"weapon capacity" -19
-	"pylon" -1
+	pylon -1
 	"tracker capacity" 56
 	weapon
 		sprite "projectile/tracker"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -824,7 +824,7 @@ outfit "Meteor Missile Launcher"
 	"mass" 8
 	"outfit space" -14
 	"weapon capacity" -14
-	"pylon" -1
+	pylon -1
 	"meteor capacity" 30
 	weapon
 		sprite "projectile/meteor"
@@ -860,7 +860,7 @@ outfit "Meteor Missile Pod"
 	"mass" 1
 	"outfit space" -3
 	"weapon capacity" -3
-	"pylon" -1
+	pylon -1
 	"meteor capacity" 7
 	weapon
 		sprite "projectile/meteor"
@@ -925,7 +925,7 @@ outfit "Sidewinder Missile Launcher"
 	"mass" 11
 	"outfit space" -20
 	"weapon capacity" -20
-	"pylon" -1
+	pylon -1
 	"sidewinder capacity" 45
 	weapon
 		sprite "projectile/sidewinder"
@@ -962,7 +962,7 @@ outfit "Sidewinder Missile Pod"
 	"mass" 2
 	"outfit space" -4
 	"weapon capacity" -4
-	"pylon" -1
+	pylon -1
 	"sidewinder capacity" 6
 	weapon
 		sprite "projectile/sidewinder"
@@ -1029,7 +1029,7 @@ outfit "Javelin Pod"
 	"mass" 4
 	"outfit space" -12
 	"weapon capacity" -12
-	"pylon" -1
+	pylon -1
 	"javelin capacity" 200
 	weapon
 		sprite "projectile/javelin"
@@ -1057,7 +1057,7 @@ outfit "Javelin Mini Pod"
 	"mass" 1
 	"outfit space" -3
 	"weapon capacity" -3
-	"pylon" -1
+	pylon -1
 	"javelin capacity" 30
 	weapon
 		sprite "projectile/javelin"
@@ -1139,7 +1139,7 @@ outfit "Torpedo Launcher"
 	"mass" 18
 	"outfit space" -30
 	"weapon capacity" -30
-	"pylon" -1
+	pylon -1
 	"torpedo capacity" 30
 	weapon
 		sprite "projectile/torpedo"
@@ -1175,7 +1175,7 @@ outfit "Torpedo Pod"
 	"mass" 5
 	"outfit space" -8
 	"weapon capacity" -8
-	"pylon" -1
+	pylon -1
 	"torpedo capacity" 3
 	weapon
 		sprite "projectile/torpedo"
@@ -1240,7 +1240,7 @@ outfit "Typhoon Launcher"
 	"mass" 25
 	"outfit space" -40
 	"weapon capacity" -40
-	"pylon" -1
+	pylon -1
 	"typhoon capacity" 30
 	weapon
 		sprite "projectile/typhoon"
@@ -1276,7 +1276,7 @@ outfit "Typhoon Pod"
 	"mass" 6
 	"outfit space" -12
 	"weapon capacity" -12
-	"pylon" -1
+	pylon -1
 	"typhoon capacity" 3
 	weapon
 		sprite "projectile/typhoon"
@@ -1340,7 +1340,7 @@ outfit "Heavy Rocket Launcher"
 	"mass" 15
 	"outfit space" -25
 	"weapon capacity" -25
-	"pylon" -1
+	pylon -1
 	"rocket capacity" 20
 	weapon
 		sprite "projectile/rocket"
@@ -1373,7 +1373,7 @@ outfit "Heavy Rocket Pod"
 	"mass" 3
 	"outfit space" -6
 	"weapon capacity" -6
-	"pylon" -1
+	pylon -1
 	"rocket capacity" 2
 	weapon
 		sprite "projectile/rocket"
@@ -1422,7 +1422,7 @@ outfit "Nuclear Missile"
 	"mass" 10
 	"outfit space" -10
 	"weapon capacity" -10
-	"pylon" -1
+	pylon -1
 	weapon
 		sprite "projectile/missile"
 			"no repeat"

--- a/data/human/weapons.txt
+++ b/data/human/weapons.txt
@@ -824,7 +824,7 @@ outfit "Meteor Missile Launcher"
 	"mass" 8
 	"outfit space" -14
 	"weapon capacity" -14
-	pylon -1
+	"missile pylons" -1
 	"meteor capacity" 30
 	weapon
 		sprite "projectile/meteor"
@@ -860,7 +860,7 @@ outfit "Meteor Missile Pod"
 	"mass" 1
 	"outfit space" -3
 	"weapon capacity" -3
-	pylon -1
+	"missile pylons" -1
 	"meteor capacity" 7
 	weapon
 		sprite "projectile/meteor"
@@ -925,7 +925,7 @@ outfit "Sidewinder Missile Launcher"
 	"mass" 11
 	"outfit space" -20
 	"weapon capacity" -20
-	pylon -1
+	"missile pylons" -1
 	"sidewinder capacity" 45
 	weapon
 		sprite "projectile/sidewinder"
@@ -962,7 +962,7 @@ outfit "Sidewinder Missile Pod"
 	"mass" 2
 	"outfit space" -4
 	"weapon capacity" -4
-	pylon -1
+	"missile pylons" -1
 	"sidewinder capacity" 6
 	weapon
 		sprite "projectile/sidewinder"
@@ -1029,7 +1029,7 @@ outfit "Javelin Pod"
 	"mass" 4
 	"outfit space" -12
 	"weapon capacity" -12
-	pylon -1
+	"missile pylons" -1
 	"javelin capacity" 200
 	weapon
 		sprite "projectile/javelin"
@@ -1057,7 +1057,7 @@ outfit "Javelin Mini Pod"
 	"mass" 1
 	"outfit space" -3
 	"weapon capacity" -3
-	pylon -1
+	"missile pylons" -1
 	"javelin capacity" 30
 	weapon
 		sprite "projectile/javelin"
@@ -1139,7 +1139,7 @@ outfit "Torpedo Launcher"
 	"mass" 18
 	"outfit space" -30
 	"weapon capacity" -30
-	pylon -1
+	"missile pylons" -1
 	"torpedo capacity" 30
 	weapon
 		sprite "projectile/torpedo"
@@ -1175,7 +1175,7 @@ outfit "Torpedo Pod"
 	"mass" 5
 	"outfit space" -8
 	"weapon capacity" -8
-	pylon -1
+	"missile pylons" -1
 	"torpedo capacity" 3
 	weapon
 		sprite "projectile/torpedo"
@@ -1240,7 +1240,7 @@ outfit "Typhoon Launcher"
 	"mass" 25
 	"outfit space" -40
 	"weapon capacity" -40
-	pylon -1
+	"missile pylons" -1
 	"typhoon capacity" 30
 	weapon
 		sprite "projectile/typhoon"
@@ -1276,7 +1276,7 @@ outfit "Typhoon Pod"
 	"mass" 6
 	"outfit space" -12
 	"weapon capacity" -12
-	pylon -1
+	"missile pylons" -1
 	"typhoon capacity" 3
 	weapon
 		sprite "projectile/typhoon"
@@ -1340,7 +1340,7 @@ outfit "Heavy Rocket Launcher"
 	"mass" 15
 	"outfit space" -25
 	"weapon capacity" -25
-	pylon -1
+	"missile pylons" -1
 	"rocket capacity" 20
 	weapon
 		sprite "projectile/rocket"
@@ -1373,7 +1373,7 @@ outfit "Heavy Rocket Pod"
 	"mass" 3
 	"outfit space" -6
 	"weapon capacity" -6
-	pylon -1
+	"missile pylons" -1
 	"rocket capacity" 2
 	weapon
 		sprite "projectile/rocket"
@@ -1422,7 +1422,7 @@ outfit "Nuclear Missile"
 	"mass" 10
 	"outfit space" -10
 	"weapon capacity" -10
-	pylon -1
+	"missile pylons" -1
 	weapon
 		sprite "projectile/missile"
 			"no repeat"

--- a/data/incipias/incipias outfits.txt
+++ b/data/incipias/incipias outfits.txt
@@ -96,7 +96,7 @@ outfit "Star Tail"
 	mass 48
 	"outfit space" -50
 	"weapon capacity" -50
-	"pylon" -1
+	pylon -1
 	thumbnail "outfit/star tail launcher"
 	"star tail capacity" 20
 	licenses

--- a/data/incipias/incipias outfits.txt
+++ b/data/incipias/incipias outfits.txt
@@ -96,7 +96,7 @@ outfit "Star Tail"
 	mass 48
 	"outfit space" -50
 	"weapon capacity" -50
-	pylon -1
+	"missile pylons" -1
 	thumbnail "outfit/star tail launcher"
 	"star tail capacity" 20
 	licenses

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -233,7 +233,7 @@ outfit "Ka'het EMP Deployer"
 	"mass" 18
 	"outfit space" -26
 	"weapon capacity" -26
-	pylon -1
+	"missile pylons" -1
 	"emp torpedo capacity" 16
 	weapon
 		sprite "projectile/emp torpedo"
@@ -276,7 +276,7 @@ outfit "Ka'het Emergency Deployer"
 	thumbnail "outfit/ka'het mhd deployer"
 	"mass" 13
 	"outfit space" -17
-	pylon -1
+	"missile pylons" -1
 	weapon
 		sprite "projectile/mhd"
 			"frame rate" 2

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -233,7 +233,7 @@ outfit "Ka'het EMP Deployer"
 	"mass" 18
 	"outfit space" -26
 	"weapon capacity" -26
-	"pylon" -1
+	pylon -1
 	"emp torpedo capacity" 16
 	weapon
 		sprite "projectile/emp torpedo"
@@ -276,7 +276,7 @@ outfit "Ka'het Emergency Deployer"
 	thumbnail "outfit/ka'het mhd deployer"
 	"mass" 13
 	"outfit space" -17
-	"pylon" -1
+	pylon -1
 	weapon
 		sprite "projectile/mhd"
 			"frame rate" 2

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -413,7 +413,7 @@ outfit "Piercer Missile Launcher"
 	"outfit space" -27
 	"weapon capacity" -27
 	"energy capacity" 50
-	pylon -1
+	"missile pylons" -1
 	"piercer capacity" 31
 	weapon
 		sprite "projectile/piercer"
@@ -565,7 +565,7 @@ outfit "Cluster Mine Layer"
 	"outfit space" -48
 	"weapon capacity" -48
 	"energy capacity" 50
-	pylon -1
+	"missile pylons" -1
 	"minelayer capacity" 17
 	weapon
 		sprite "projectile/korath minelayer"
@@ -926,7 +926,7 @@ outfit "Firelight Missile Bank"
 	"mass" 22
 	"outfit space" -28
 	"weapon capacity" -28
-	pylon -1
+	"missile pylons" -1
 	"energy capacity" 700
 	"firelight missile capacity" 20
 	weapon

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -413,7 +413,7 @@ outfit "Piercer Missile Launcher"
 	"outfit space" -27
 	"weapon capacity" -27
 	"energy capacity" 50
-	"pylon" -1
+	pylon -1
 	"piercer capacity" 31
 	weapon
 		sprite "projectile/piercer"
@@ -565,7 +565,7 @@ outfit "Cluster Mine Layer"
 	"outfit space" -48
 	"weapon capacity" -48
 	"energy capacity" 50
-	"pylon" -1
+	pylon -1
 	"minelayer capacity" 17
 	weapon
 		sprite "projectile/korath minelayer"
@@ -926,7 +926,7 @@ outfit "Firelight Missile Bank"
 	"mass" 22
 	"outfit space" -28
 	"weapon capacity" -28
-	"pylon" -1
+	pylon -1
 	"energy capacity" 700
 	"firelight missile capacity" 20
 	weapon

--- a/data/pug/pug outfits.txt
+++ b/data/pug/pug outfits.txt
@@ -80,7 +80,7 @@ outfit "Pug Seeker"
 	"mass" 34
 	"outfit space" -34
 	"weapon capacity" -34
-	"pylon" -1
+	pylon -1
 	weapon
 		sprite "projectile/seeker"
 			"frame rate" 20

--- a/data/pug/pug outfits.txt
+++ b/data/pug/pug outfits.txt
@@ -80,7 +80,7 @@ outfit "Pug Seeker"
 	"mass" 34
 	"outfit space" -34
 	"weapon capacity" -34
-	pylon -1
+	"missile pylons" -1
 	weapon
 		sprite "projectile/seeker"
 			"frame rate" 20

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -244,7 +244,7 @@ outfit "EMP Torpedo Bay"
 	"mass" 9
 	"outfit space" -18
 	"weapon capacity" -18
-	"pylon" -1
+	pylon -1
 	"emp torpedo capacity" 9
 	weapon
 		sprite "projectile/emp torpedo"
@@ -317,7 +317,7 @@ outfit "Teciimach Bay"
 	"mass" 9
 	"outfit space" -13
 	"weapon capacity" -13
-	"pylon" -1
+	pylon -1
 	"teciimach canister capacity" 9
 	weapon
 		sprite "projectile/emp torpedo"
@@ -367,7 +367,7 @@ outfit "Teciimach Pod"
 	"mass" 3
 	"outfit space" -6
 	"weapon capacity" -6
-	"pylon" -1
+	pylon -1
 	"teciimach canister capacity" 3
 	weapon
 		sprite "projectile/emp torpedo"

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -244,7 +244,7 @@ outfit "EMP Torpedo Bay"
 	"mass" 9
 	"outfit space" -18
 	"weapon capacity" -18
-	pylon -1
+	"missile pylons" -1
 	"emp torpedo capacity" 9
 	weapon
 		sprite "projectile/emp torpedo"
@@ -317,7 +317,7 @@ outfit "Teciimach Bay"
 	"mass" 9
 	"outfit space" -13
 	"weapon capacity" -13
-	pylon -1
+	"missile pylons" -1
 	"teciimach canister capacity" 9
 	weapon
 		sprite "projectile/emp torpedo"
@@ -367,7 +367,7 @@ outfit "Teciimach Pod"
 	"mass" 3
 	"outfit space" -6
 	"weapon capacity" -6
-	pylon -1
+	"missile pylons" -1
 	"teciimach canister capacity" 3
 	weapon
 		sprite "projectile/emp torpedo"

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -320,7 +320,7 @@ outfit "Shard Fabricator"
 	"outfit space" -10
 	"weapon capacity" -7
 	"fuel capacity" 36
-	"pylon" -1
+	pylon -1
 	"unique" 1
 	"operating costs" 150
 	weapon

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -320,7 +320,7 @@ outfit "Shard Fabricator"
 	"outfit space" -10
 	"weapon capacity" -7
 	"fuel capacity" 36
-	pylon -1
+	"missile pylons" -1
 	"unique" 1
 	"operating costs" 150
 	weapon

--- a/data/successors/successor weapons.txt
+++ b/data/successors/successor weapons.txt
@@ -335,7 +335,7 @@ outfit `"Sjeja" Kinetic Lance`
 	"outfit space" -60
 	"weapon capacity" -60
 	"energy capacity" 1900
-	pylon -1
+	"missile pylons" -1
 	"spike capacity" 20
 	weapon
 		sprite "projectile/sjeja kinetic lance"

--- a/data/successors/successor weapons.txt
+++ b/data/successors/successor weapons.txt
@@ -335,7 +335,7 @@ outfit `"Sjeja" Kinetic Lance`
 	"outfit space" -60
 	"weapon capacity" -60
 	"energy capacity" 1900
-	"pylon" -1
+	pylon -1
 	"spike capacity" 20
 	weapon
 		sprite "projectile/sjeja kinetic lance"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -223,7 +223,7 @@ outfit "Thunderhead Launcher"
 	"mass" 14
 	"outfit space" -26
 	"weapon capacity" -26
-	pylon -1
+	"missile pylons" -1
 	"thunderhead capacity" 40
 	weapon
 		sprite "projectile/thunderhead"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -223,7 +223,7 @@ outfit "Thunderhead Launcher"
 	"mass" 14
 	"outfit space" -26
 	"weapon capacity" -26
-	"pylon" -1
+	pylon -1
 	"thunderhead capacity" 40
 	weapon
 		sprite "projectile/thunderhead"

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -68,7 +68,7 @@ int Armament::Add(const Outfit *outfit, int count)
 	int existing = 0;
 	int added = 0;
 	bool isTurret = outfit->Get("turret mounts");
-	bool isPylon = outfit->Get("missile pylon");
+	bool isPylon = outfit->Get("missile pylons");
 	bool isGun = outfit->Get("gun ports");
 	// Do not equip weapons that do not define how they are mounted.
 	if(!isTurret && !isPylon && !isGun)

--- a/source/Armament.cpp
+++ b/source/Armament.cpp
@@ -68,13 +68,13 @@ int Armament::Add(const Outfit *outfit, int count)
 	int existing = 0;
 	int added = 0;
 	bool isTurret = outfit->Get("turret mounts");
-	bool isPylon = outfit->Get("pylon");
+	bool isPylon = outfit->Get("missile pylon");
 	bool isGun = outfit->Get("gun ports");
 	// Do not equip weapons that do not define how they are mounted.
 	if(!isTurret && !isPylon && !isGun)
 	{
 		Logger::LogError("Error: Skipping unmountable outfit \"" + outfit->TrueName() + "\"."
-			" Weapon outfits must specify \"gun ports\", \"turret mounts\", or \"pylon\".");
+			" Weapon outfits must specify \"gun ports\", \"turret mounts\", or \"missile pylon\".");
 		return 0;
 	}
 

--- a/source/Hardpoint.h
+++ b/source/Hardpoint.h
@@ -30,7 +30,7 @@ class Visual;
 
 
 
-// A single weapon hardpoint on the ship (i.e. a gun port or turret mount),
+// A single weapon hardpoint on the ship (i.e. a gun port, turret mount, or missile pylon),
 // which may or may not have a weapon installed.
 class Hardpoint {
 public:

--- a/source/HardpointInfoPanel.cpp
+++ b/source/HardpointInfoPanel.cpp
@@ -484,7 +484,7 @@ void HardpointInfoPanel::DrawWeapons(const Rectangle & bounds)
 		if(isGun == true)
 			name = "[empty gun port]";
 		if(isPylon == true)
-			name = "[empty pylon]";
+			name = "[empty missile pylon]";
 		if(isTurret == true)
 			name = "[empty turret mount]";
 		if(hardpoint.GetOutfit())

--- a/source/OutfitInfoDisplay.cpp
+++ b/source/OutfitInfoDisplay.cpp
@@ -417,7 +417,7 @@ void OutfitInfoDisplay::UpdateAttributes(const Outfit &outfit)
 	// don't use SCALE or BOOLEAN_ATTRIBUTES.
 	static const vector<string> EXPECTED_NEGATIVE = {
 		"outfit space", "weapon capacity", "engine capacity", "engine mod space", "reverse thruster slot",
-		"steering slot", "thruster slot", "gun ports", "turret mounts", "pylon"
+		"steering slot", "thruster slot", "gun ports", "turret mounts", "missile pylons"
 	};
 
 	for(const string &attr : EXPECTED_NEGATIVE)

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -486,8 +486,8 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 		int pylonNeeded = -selectedOutfit->Get("pylon");
 		int pylonFree = playerShip->Attributes().Get("pylon");
 		if(pylonNeeded && !pylonFree)
-			return "This weapon is designed to be installed on a pylon, "
-				"but your ship does not have an unused pylon available.";
+			return "This weapon is designed to be installed on a missile pylon, "
+				"but your ship does not have an unused missile pylons available.";
 
 		if(selectedOutfit->Get("installable") < 0.)
 			errors.push_back("This item is not an outfit that can be installed in a ship.");

--- a/source/OutfitterPanel.cpp
+++ b/source/OutfitterPanel.cpp
@@ -483,8 +483,8 @@ ShopPanel::BuyResult OutfitterPanel::CanBuy(bool onlyOwned) const
 			errors.push_back("This weapon is designed to be installed in a gun port, "
 				"but your ship does not have any unused gun ports available.");
 
-		int pylonNeeded = -selectedOutfit->Get("pylon");
-		int pylonFree = playerShip->Attributes().Get("pylon");
+		int pylonNeeded = -selectedOutfit->Get("missile pylons");
+		int pylonFree = playerShip->Attributes().Get("missile pylons");
 		if(pylonNeeded && !pylonFree)
 			return "This weapon is designed to be installed on a missile pylon, "
 				"but your ship does not have an unused missile pylons available.";

--- a/source/PrintData.cpp
+++ b/source/PrintData.cpp
@@ -151,7 +151,7 @@ namespace {
 				<< DataWriter::Quote("engine mod space") << ',' << DataWriter::Quote("reverse thruster slot") << ','
 				<< DataWriter::Quote("steering slot") << ',' << DataWriter::Quote("thruster slot") << ','
 				<< DataWriter::Quote("gun mounts") << ',' << DataWriter::Quote("turret mounts") << ','
-				<< DataWriter::Quote("pylon") << ','
+				<< DataWriter::Quote("missile pylons") << ','
 				<< DataWriter::Quote("fighter bays") << ',' << DataWriter::Quote("drone bays") << '\n';
 
 			for(auto &it : GameData::Ships())
@@ -216,7 +216,7 @@ namespace {
 				<< DataWriter::Quote("energy capacity") << ',' << DataWriter::Quote("idle/max heat") << ','
 				<< DataWriter::Quote("max heat generation") << ',' << DataWriter::Quote("max heat dissipation") << ','
 				<< DataWriter::Quote("gun mounts") << ',' << DataWriter::Quote("turret mounts") << ','
-				<< DataWriter::Quote("pylon") << ','
+				<< DataWriter::Quote("missile pylons") << ','
 				<< DataWriter::Quote("fighter bays") << ',' << DataWriter::Quote("drone bays") << ',' << "deterrence" << '\n';
 
 			for(auto &it : GameData::Ships())

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -749,7 +749,7 @@ void Ship::FinishLoading(bool isNewInstance)
 
 	baseAttributes.Set("gun ports", armament.GunCount());
 	baseAttributes.Set("turret mounts", armament.TurretCount());
-	baseAttributes.Set("pylon", armament.PylonCount());
+	baseAttributes.Set("missile pylons", armament.PylonCount());
 
 	if(addAttributes)
 	{
@@ -811,9 +811,9 @@ void Ship::FinishLoading(bool isNewInstance)
 
 		Logger::LogError(message);
 	}
-	// Inspect the ship's armament to ensure that guns are in gun ports and
-	// turrets are in turret mounts. This can only happen when the armament
-	// is configured incorrectly in a ship or variant definition. Do not
+	// Inspect the ship's armament to ensure that guns are in gun ports, turrets are
+	// in turret mounts, and missiles in missile pylons. This can only happen when the
+	// armament is configured incorrectly in a ship or variant definition. Do not
 	// bother printing this warning if the outfit is not fully defined.
 	// Note the GT in the two outputs for the first test stand for Gun Test
 	// while the TT in the second set of two outputs is for Turret Test,
@@ -848,7 +848,7 @@ void Ship::FinishLoading(bool isNewInstance)
 			warning += " \"" + outfit->TrueName() + "\"";
 			Logger::LogError(warning);
 		}
-		if(outfit && (hardpoint.IsPylon() != (outfit->Get("pylon") != 0.)))
+		if(outfit && (hardpoint.IsPylon() != (outfit->Get("missile pylons") != 0.)))
 		{
 			string warning = (!isYours && !variantName.empty()) ? "variant \"" + variantName + "\"" : trueModelName;
 			if(!name.empty())

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -305,7 +305,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		"thruster slots free:", "thruster slot",
 		"gun ports free:", "gun ports",
 		"turret mounts free:", "turret mounts",
-		"pylons free:", "pylon"
+		"missile pylons free:", "pylon"
 	};
 	for(unsigned i = 1; i < NAMES.size(); i += 2)
 		chassis[NAMES[i]] = attributes.Get(NAMES[i]);
@@ -945,7 +945,7 @@ void ShipInfoDisplay::DrawShipHardpointStats(const Ship &ship, const Rectangle &
 	static const vector<string> NAMES = {
 		"gun ports free:", "gun ports",
 		"turret mounts free:", "turret mounts",
-		"pylons free:", "pylon"
+		"missile pylons free:", "pylon"
 	};
 
 	for(unsigned i = 1; i < NAMES.size(); i += 2)

--- a/source/ShipInfoDisplay.cpp
+++ b/source/ShipInfoDisplay.cpp
@@ -305,7 +305,7 @@ void ShipInfoDisplay::UpdateAttributes(const Ship &ship, const PlayerInfo &playe
 		"thruster slots free:", "thruster slot",
 		"gun ports free:", "gun ports",
 		"turret mounts free:", "turret mounts",
-		"missile pylons free:", "pylon"
+		"missile pylons free:", "missile pylons"
 	};
 	for(unsigned i = 1; i < NAMES.size(); i += 2)
 		chassis[NAMES[i]] = attributes.Get(NAMES[i]);
@@ -945,7 +945,7 @@ void ShipInfoDisplay::DrawShipHardpointStats(const Ship &ship, const Rectangle &
 	static const vector<string> NAMES = {
 		"gun ports free:", "gun ports",
 		"turret mounts free:", "turret mounts",
-		"missile pylons free:", "pylon"
+		"missile pylons free:", "missile pylons"
 	};
 
 	for(unsigned i = 1; i < NAMES.size(); i += 2)


### PR DESCRIPTION
It was pointed out (thanks @ravenshining !) that "pylon" is not very informative as to what the thing actually is or for. Changing it to "missile pylon" would make it very self-evident exactly what it was for, and thus be much more user-friendly.

As such, this PR makes that change. 

It also adds some tooltip text, and modifies the gun and turret tooltip text a bit to properly reflect the changed weapon hardpoint environment.