### PR TITLE
feat(data): Two more person ships: Intola and Verdorve

### DIFF
--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -24,9 +24,9 @@ gamerules
 	"universal ramscoop" false
 	
 	# An attempt to spawn a person ship happens on average every this many frames.
-	# DEFAULT: 9000 frames (two and a half minutes)
+	# DEFAULT: 36000 frames (ten minutes)
 	# ALLOWABLE VALUES: any integer >= 1
-	"person spawn period" 9000
+	"person spawn period" 36000
 	
 	# While an attempt to spawn a person ship is made on average every number of frames specified
 	# above, a person ship may still not spawn. Each person ship has a "weight" associated with them

--- a/data/gamerules.txt
+++ b/data/gamerules.txt
@@ -24,9 +24,9 @@ gamerules
 	"universal ramscoop" false
 	
 	# An attempt to spawn a person ship happens on average every this many frames.
-	# DEFAULT: 72000 frames (twenty minutes)
+	# DEFAULT: 9000 frames (two and a half minutes)
 	# ALLOWABLE VALUES: any integer >= 1
-	"person spawn period" 72000
+	"person spawn period" 9000
 	
 	# While an attempt to spawn a person ship is made on average every number of frames specified
 	# above, a person ship may still not spawn. Each person ship has a "weight" associated with them

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -2437,3 +2437,102 @@ ship "Cicada" "Cicada (Sanujab)"
 	turret "Bullfrog Anti-Missile"
 	turret
 	turret
+
+
+
+person "Intola"
+	government "Merchant"
+	frequency 100
+	personality
+		disables plunders
+	system
+		government "Free Worlds" "Neutral" "Pirate" "Republic" "Syndicate"
+	phrase
+		word
+			"Do you know how useless radar jammers are?"
+			"I love exploring."
+			"I got my atomic engines from ${deep planets}. Not exactly legitimately..."
+			"The best thing in the universe to do is shoot pirates!"
+			"Pirates are sometimes annoying, but I've figured out how to deal with the scoundrels."
+			"Speed is better then power."
+			"Lots of people like weapons, but I wouldn't trade my engines for anything."
+			"Ramscoops are excellent when you're exploring, but they take up a lot of space otherwise."
+			"Never run out of power. A doomed ship is a dead ship."
+			"You want to know why I don't have any cooling? I don't like being cold."
+			"Pirates are all over the galaxy, aren't they?"
+			"Those Quarg; so powerful!"
+			"Which would you prefer, a Scout or a Bounder? Answer in five seconds, and my guns are trained on you."
+			"There are interesting anomalies in this galaxy. I wonder what lies on the other side?"
+			"Cargo hauling is the least glamorous way to make a living I've ever heard of."
+	ship "Scout (Intola)" "Intola"
+
+
+
+ship "Scout" "Scout (Intola)"
+	outfits
+		"Heavy Laser" 2
+
+		"nGVF-CC Fuel Cell"
+		"LP036a Battery Pack"
+		"D14-RN Shield Generator"
+		"Ramscoop" 3
+
+		"A250 Atomic Thruster"
+		"A255 Atomic Steering"
+		"Hyperdrive"
+	gun "Heavy Laser"
+	gun "Heavy Laser"
+	pylon
+	pylon
+	turret
+
+
+
+person "Verdorve"
+	government "Merchant"
+	frequency 100
+	personality
+		vindictive
+	system
+		government "Free Worlds" "Pirate" "Republic" "Syndicate"
+	phrase
+		word
+			"When you scan my ship, you see the Power of Plasma."
+			"The default Splinter comes equipped for speed, not power. I changed that."
+			"Plasma weapons are great at overheating. The only problem is, I overheat myself."
+			"Shooting pirates is the only worthwhile thing to do."
+			"There are these strange 'bad guys' appearing out of nowhere near where I got this ship. I really like them; they seem to be overheaters. Just like me." # This allusion to the Korath may be too obvious, but it's a great reference.
+			"Guess what. The Republic leader is an Alpha. I wish I could be teleported to Earth."
+			"Nunki once paid me tribute, but no more. Or was it Bloodsea?"
+			"Shoot 'em. Bang bang."
+			"Gatling Guns are ridiculously overpowered and expensive."
+			"Exploring the Confederated Councils of the Outer Rim's former territory is a nightmare. How do they have so many Leviathans?"
+			"You'll never guess where I got my name... or what it is."
+			"The Splinter is Megaparsec's best ship. Those Protectors are too slow, and Quicksilvers can't hold Plasma Turrets."
+			"Plasma, plasma. Overheat, overheat. Shoot, shoot."
+			"I wish I could join the Navy, but they won't let me. I refuse to give up this Splinter."
+			"I wish I could join the Syndicate, but they won't let me. For some reason, the corporate leaders have a prejudice against Southbound-sold weapons. Poor plasma."
+	ship "Splinter (Verdorve)" "Verdorve"
+
+
+
+ship "Splinter" "Splinter (Verdorve)"
+	outfits
+		"Plasma Turret" 2
+
+		"Liquid Sodium Cooler"
+		"RT-I Radiothermal"
+		"D67-TM Shield Generator"
+		"Outfits Expansion"
+
+		"Impala Plasma Steering"
+		"Greyhound Plasma Thruster"
+		"Volcano Afterburner"
+		"Hyperdrive"
+	gun
+	gun
+	pylon
+	pylon
+	turret "Plasma Turret"
+	turret "Plasma Turret"
+	turret "Plasma Turret"

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -2399,7 +2399,7 @@ person "Sanujab"
 	government "Hai"
 	frequency 100
 	personality
-		disables harvests timid
+		disables getaway harvests timid
 	system
 		government "Hai" "Quarg (Hai)"
 	phrase
@@ -2444,7 +2444,7 @@ person "Intola"
 	government "Merchant"
 	frequency 100
 	personality
-		disables plunders
+		disables hunting plunders secretive
 	system
 		government "Free Worlds" "Neutral" "Pirate" "Republic" "Syndicate"
 	phrase
@@ -2492,7 +2492,7 @@ person "Verdorve"
 	government "Merchant"
 	frequency 100
 	personality
-		vindictive
+		heroic opportunistic vindictive
 	system
 		government "Free Worlds" "Pirate" "Republic" "Syndicate"
 	phrase

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -2520,10 +2520,10 @@ ship "Splinter" "Splinter (Verdorve)"
 	outfits
 		"Plasma Turret" 2
 
-		"Liquid Sodium Cooler"
+		"Liquid Sodium Cooler" 2
 		"RT-I Radiothermal"
 		"D67-TM Shield Generator"
-		"Outfits Expansion"
+		"Outfits Expansion" 2
 
 		"Impala Plasma Steering"
 		"Greyhound Plasma Thruster"
@@ -2533,6 +2533,6 @@ ship "Splinter" "Splinter (Verdorve)"
 	gun
 	pylon
 	pylon
-	turret "Plasma Turret"
+	turret
 	turret "Plasma Turret"
 	turret "Plasma Turret"


### PR DESCRIPTION
**Content (Person Ships)**

## Summary

Follow-up to #136 and #135. Re-PR of #143 after a git mistake.
Intola is a Scout with two Heavy Lasers as armament. I wondered about giving it a Quantum Keystone, but that's a little spoilery.
Verdorve's captain loves plasma weapons and engines, and the Splinter Verdorve flies uses nothing but plasma.

Halves the person spawn rate.