### PR TITLE
feat(data): Replacing small killer pirate variants with new variants better suited to looting

### DIFF
--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1964,17 +1964,17 @@ fleet "Small Southern Pirates"
 	variant 2
 		"Hawk (Speedy)"
 	variant 2
-		"Hawk (Rocket)"
+		"Hawk (Raider)"
 	variant 5
 		"Fury"
 	variant 4
-		"Fury (Bomber)"
+		"Fury (Raider)"
 	variant 1
 		"Fury (Laser)"
 	variant 1
 		"Fury (Gatling)"
 	variant 1
-		"Fury (Missile)"
+		"Fury (Raider Missile)"
 	variant 1
 		"Fury (Heavy)"
 	variant 4
@@ -1988,7 +1988,7 @@ fleet "Small Southern Pirates"
 	variant 1
 		"Fury" 3
 	variant 1
-		"Fury (Missile)" 2
+		"Fury (Raider Missile)" 2
 	variant 1
 		"Fury (Heavy)" 2
 	variant 1
@@ -1999,13 +1999,13 @@ fleet "Small Southern Pirates"
 		"Fury"
 		"Sparrow"
 	variant 1
-		"Hawk (Rocket)"
-		"Fury (Missile)"
+		"Hawk (Raider)"
+		"Fury (Raider Missile)"
 		"Sparrow"
 	variant 1
 		"Sparrow" 3
 	variant 1
-		"Fury (Bomber)"
+		"Fury (Raider)"
 		"Sparrow"
 	variant 1
 		"Hawk" 2
@@ -2014,7 +2014,7 @@ fleet "Small Southern Pirates"
 	variant 2
 		"Clipper"
 	variant 1
-		"Clipper (Heavy)"
+		"Clipper (Raider)"
 	variant 1
 		"Clipper (Speedy)"
 	variant 1
@@ -2073,7 +2073,7 @@ fleet "Large Southern Pirates"
 	variant 4
 		"Clipper"
 	variant 2
-		"Clipper (Heavy)"
+		"Clipper (Raider)"
 	variant 2
 		"Clipper (Speedy)"
 	variant 1
@@ -2090,13 +2090,13 @@ fleet "Large Southern Pirates"
 		"Clipper"
 		"Hawk"
 	variant 1
-		"Clipper (Heavy)"
-		"Hawk (Rocket)"
+		"Clipper (Raider)"
+		"Hawk (Raider)"
 	variant 2
 		"Hawk (Bomber)"
 		"Sparrow" 3
 	variant 2
-		"Fury (Bomber)"
+		"Fury (Raider)"
 		"Sparrow" 3
 	variant 1
 		"Clipper (Speedy)"
@@ -2105,14 +2105,14 @@ fleet "Large Southern Pirates"
 		"Hawk (Bomber)"
 		"Fury (Gatling)" 2
 	variant 1
-		"Fury (Bomber)"
+		"Fury (Raider)"
 		"Fury (Gatling)" 2
 	variant 3
 		"Argosy"
 		"Hawk"
 	variant 1
 		"Argosy (Blaster)"
-		"Hawk (Rocket)"
+		"Hawk (Raider)"
 	variant 1
 		"Argosy (Laser)"
 		"Hawk (Speedy)"
@@ -2121,7 +2121,7 @@ fleet "Large Southern Pirates"
 		"Hawk (Speedy)"
 	variant 1
 		"Argosy (Missile)"
-		"Hawk (Rocket)"
+		"Hawk (Raider)"
 	variant 1
 		"Modified Argosy"
 		"Sparrow" 2
@@ -2255,7 +2255,7 @@ fleet "Small Core Pirates"
 	variant 3
 		"Hawk"
 	variant 2
-		"Hawk (Rocket)"
+		"Hawk (Raider)"
 	variant 2
 		"Hawk (Speedy)"
 	variant 1
@@ -2316,10 +2316,10 @@ fleet "Large Core Pirates"
 		"Hawk (Bomber)"
 		"Quicksilver (Proton)" 2
 	variant 3
-		"Fury (Bomber)"
+		"Fury (Raider)"
 		"Quicksilver" 2
 	variant 3
-		"Fury (Bomber)"
+		"Fury (Raider)"
 		"Quicksilver (Proton)" 2
 	variant 2
 		"Headhunter (Strike)"
@@ -2382,11 +2382,11 @@ fleet "Small Northern Pirates"
 	variant 3
 		"Fury"
 	variant 1
-		"Fury (Missile)"
+		"Fury (Raider Missile)"
 	variant 1
 		"Fury (Laser)"
 	variant 1
-		"Fury (Bomber)"
+		"Fury (Raider)"
 	variant 1
 		"Fury (Heavy)"
 	variant 2
@@ -2398,7 +2398,7 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Hawk"
 	variant 1
-		"Hawk (Rocket)"
+		"Hawk (Raider)"
 	variant 1
 		"Hawk (Speedy)"
 	variant 1
@@ -2474,10 +2474,10 @@ fleet "Large Northern Pirates"
 		"Berserker" 2
 	variant 2
 		"Firebird (Plasma)"
-		"Fury (Missile)"
+		"Fury (Raider Missile)"
 	variant 2
 		"Firebird (Missile)"
-		"Fury (Bomber)"
+		"Fury (Raider)"
 	variant 6
 		"Raven (Afterburner)" 2
 	variant 2
@@ -2647,7 +2647,7 @@ fleet "pirate raid"
 		"Berserker" 2
 	variant 1
 		"Firebird (Plasma)"
-		"Fury (Missile)"
+		"Fury (Raider Missile)"
 	variant 1
 		"Firebird (Missile)"
 		"Fury"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1828,6 +1828,128 @@ fleet "Large Syndicate"
 		"Protector (Proton)"
 		"Vanguard"
 
+fleet "Small Independent"
+	government "Independent"
+	names "pirate"
+	cargo 1
+	personality
+		disables plunders
+		confusion 20
+	variant 8
+		"Sparrow"
+	variant 3
+		"Hawk"
+	variant 2
+		"Hawk (Speedy)"
+	variant 2
+		"Hawk (Rocket)"
+	variant 5
+		"Fury"
+	variant 2
+		"Fury (Laser)"
+	variant 1
+		"Fury (Missile)"
+	variant 2
+		"Sparrow" 2
+	variant 1
+		"Hawk"
+		"Sparrow"
+	variant 1
+		"Hawk (Speedy)"
+		"Sparrow"
+	variant 1
+		"Fury" 3
+	variant 1
+		"Fury (Missile)" 3
+	variant 1
+		"Fury"
+		"Hawk"
+	variant 1
+		"Hawk"
+		"Fury"
+		"Sparrow"
+	variant 1
+		"Hawk (Rocket)"
+		"Fury (Missile)"
+		"Sparrow"
+	variant 1
+		"Sparrow" 3
+	variant 1
+		"Hawk" 2
+	variant 1
+		"Hawk (Speedy)" 2
+	variant 2
+		"Clipper"
+	variant 1
+		"Clipper (Heavy)"
+	variant 1
+		"Clipper (Speedy)"
+	variant 4
+		"Scrapper"
+	variant 3
+		"Scrapper (Minimal)"
+
+fleet "Large Independent"
+	government "Independent"
+	names "pirate"
+	cargo 1
+	personality
+		plunders
+	variant 3
+		"Sparrow" 4
+	variant 5
+		"Argosy"
+	variant 3
+		"Argosy (Blaster)"
+	variant 2
+		"Argosy (Laser)"
+	variant 2
+		"Argosy (Missile)"
+	variant 2
+		"Argosy (Turret)"
+	variant 4
+		"Clipper"
+	variant 2
+		"Clipper (Heavy)"
+	variant 2
+		"Clipper (Speedy)"
+	variant 2
+		"Clipper"
+		"Hawk"
+	variant 1
+		"Clipper (Heavy)"
+		"Hawk (Rocket)"
+	variant 1
+		"Clipper (Speedy)"
+		"Hawk (Speedy)"
+	variant 3
+		"Argosy"
+		"Hawk"
+	variant 1
+		"Argosy (Blaster)"
+		"Hawk (Rocket)"
+	variant 1
+		"Argosy (Laser)"
+		"Hawk (Speedy)"
+	variant 1
+		"Argosy (Turret)"
+		"Hawk (Speedy)"
+	variant 1
+		"Argosy (Missile)"
+		"Hawk (Rocket)"
+	variant 4
+		"Bastion"
+	variant 2
+		"Bastion (Heavy)"
+	variant 2
+		"Bastion (Laser)"
+	variant 2
+		"Falcon"
+	variant 1
+		"Falcon (Heavy)"
+	variant 1
+		"Falcon (Laser)"
+
 fleet "Small Southern Pirates"
 	government "Pirate"
 	names "pirate"
@@ -2116,128 +2238,6 @@ fleet "CCOR Logistics"
 	variant 1
 		"Hogshead (CCOR)"
 		"Enforcer (CCOR)"
-
-fleet "Small Independent"
-	government "Independent"
-	names "pirate"
-	cargo 1
-	personality
-		disables plunders
-		confusion 20
-	variant 8
-		"Sparrow"
-	variant 3
-		"Hawk"
-	variant 2
-		"Hawk (Speedy)"
-	variant 2
-		"Hawk (Rocket)"
-	variant 5
-		"Fury"
-	variant 2
-		"Fury (Laser)"
-	variant 1
-		"Fury (Missile)"
-	variant 2
-		"Sparrow" 2
-	variant 1
-		"Hawk"
-		"Sparrow"
-	variant 1
-		"Hawk (Speedy)"
-		"Sparrow"
-	variant 1
-		"Fury" 3
-	variant 1
-		"Fury (Missile)" 3
-	variant 1
-		"Fury"
-		"Hawk"
-	variant 1
-		"Hawk"
-		"Fury"
-		"Sparrow"
-	variant 1
-		"Hawk (Rocket)"
-		"Fury (Missile)"
-		"Sparrow"
-	variant 1
-		"Sparrow" 3
-	variant 1
-		"Hawk" 2
-	variant 1
-		"Hawk (Speedy)" 2
-	variant 2
-		"Clipper"
-	variant 1
-		"Clipper (Heavy)"
-	variant 1
-		"Clipper (Speedy)"
-	variant 4
-		"Scrapper"
-	variant 3
-		"Scrapper (Minimal)"
-
-fleet "Large Independent"
-	government "Independent"
-	names "pirate"
-	cargo 1
-	personality
-		plunders
-	variant 3
-		"Sparrow" 4
-	variant 5
-		"Argosy"
-	variant 3
-		"Argosy (Blaster)"
-	variant 2
-		"Argosy (Laser)"
-	variant 2
-		"Argosy (Missile)"
-	variant 2
-		"Argosy (Turret)"
-	variant 4
-		"Clipper"
-	variant 2
-		"Clipper (Heavy)"
-	variant 2
-		"Clipper (Speedy)"
-	variant 2
-		"Clipper"
-		"Hawk"
-	variant 1
-		"Clipper (Heavy)"
-		"Hawk (Rocket)"
-	variant 1
-		"Clipper (Speedy)"
-		"Hawk (Speedy)"
-	variant 3
-		"Argosy"
-		"Hawk"
-	variant 1
-		"Argosy (Blaster)"
-		"Hawk (Rocket)"
-	variant 1
-		"Argosy (Laser)"
-		"Hawk (Speedy)"
-	variant 1
-		"Argosy (Turret)"
-		"Hawk (Speedy)"
-	variant 1
-		"Argosy (Missile)"
-		"Hawk (Rocket)"
-	variant 4
-		"Bastion"
-	variant 2
-		"Bastion (Heavy)"
-	variant 2
-		"Bastion (Laser)"
-	variant 2
-		"Falcon"
-	variant 1
-		"Falcon (Heavy)"
-	variant 1
-		"Falcon (Laser)"
 
 fleet "Small Core Pirates"
 	government "Pirate"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1842,17 +1842,17 @@ fleet "Small Southern Pirates"
 	variant 2
 		"Hawk (Speedy)"
 	variant 2
-		"Hawk (Rocket)"
+		"Hawk"
 	variant 5
 		"Fury"
 	variant 4
-		"Fury (Bomber)"
+		"Fury"
 	variant 1
 		"Fury (Laser)"
 	variant 1
 		"Fury (Gatling)"
 	variant 1
-		"Fury (Missile)"
+		"Fury"
 	variant 1
 		"Fury (Heavy)"
 	variant 4
@@ -1866,7 +1866,7 @@ fleet "Small Southern Pirates"
 	variant 1
 		"Fury" 3
 	variant 1
-		"Fury (Missile)" 2
+		"Fury" 2
 	variant 1
 		"Fury (Heavy)" 2
 	variant 1
@@ -1877,13 +1877,13 @@ fleet "Small Southern Pirates"
 		"Fury"
 		"Sparrow"
 	variant 1
-		"Hawk (Rocket)"
-		"Fury (Missile)"
+		"Hawk"
+		"Fury"
 		"Sparrow"
 	variant 1
 		"Sparrow" 3
 	variant 1
-		"Fury (Bomber)"
+		"Fury"
 		"Sparrow"
 	variant 1
 		"Hawk" 2
@@ -1892,7 +1892,7 @@ fleet "Small Southern Pirates"
 	variant 2
 		"Clipper"
 	variant 1
-		"Clipper (Heavy)"
+		"Clipper"
 	variant 1
 		"Clipper (Speedy)"
 	variant 1
@@ -1921,7 +1921,7 @@ fleet "Large Southern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests getaway
+		disables plunders harvests getaway
 	variant 2
 		"Sparrow" 4
 	variant 1
@@ -1933,7 +1933,7 @@ fleet "Large Southern Pirates"
 	variant 2
 		"Argosy (Laser)"
 	variant 2
-		"Argosy (Missile)"
+		"Argosy"
 	variant 2
 		"Argosy (Turret)"
 	variant 1
@@ -1943,7 +1943,7 @@ fleet "Large Southern Pirates"
 	variant 1
 		"Modified Argosy (Blaster)"
 	variant 1
-		"Modified Argosy (Missile)"
+		"Modified Argosy"
 	variant 1
 		"Modified Argosy (Javelin)"
 	variant 1
@@ -1951,7 +1951,7 @@ fleet "Large Southern Pirates"
 	variant 4
 		"Clipper"
 	variant 2
-		"Clipper (Heavy)"
+		"Clipper"
 	variant 2
 		"Clipper (Speedy)"
 	variant 1
@@ -1961,36 +1961,36 @@ fleet "Large Southern Pirates"
 		"Osprey"
 		"Sparrow"
 	variant 1
-		"Osprey (Missile)"
+		"Osprey"
 	variant 1
 		"Osprey (Laser)"
 	variant 2
 		"Clipper"
 		"Hawk"
 	variant 1
-		"Clipper (Heavy)"
-		"Hawk (Rocket)"
+		"Clipper"
+		"Hawk"
 	variant 2
-		"Hawk (Bomber)"
+		"Hawk"
 		"Sparrow" 3
 	variant 2
-		"Fury (Bomber)"
+		"Fury"
 		"Sparrow" 3
 	variant 1
 		"Clipper (Speedy)"
 		"Hawk (Speedy)"
 	variant 1
-		"Hawk (Bomber)"
+		"Hawk"
 		"Fury (Gatling)" 2
 	variant 1
-		"Fury (Bomber)"
+		"Fury"
 		"Fury (Gatling)" 2
 	variant 3
 		"Argosy"
 		"Hawk"
 	variant 1
 		"Argosy (Blaster)"
-		"Hawk (Rocket)"
+		"Hawk"
 	variant 1
 		"Argosy (Laser)"
 		"Hawk (Speedy)"
@@ -1998,8 +1998,8 @@ fleet "Large Southern Pirates"
 		"Argosy (Turret)"
 		"Hawk (Speedy)"
 	variant 1
-		"Argosy (Missile)"
-		"Hawk (Rocket)"
+		"Argosy"
+		"Hawk"
 	variant 1
 		"Modified Argosy"
 		"Sparrow" 2
@@ -2010,10 +2010,10 @@ fleet "Large Southern Pirates"
 		"Modified Argosy (Blaster)"
 		"Sparrow" 2
 	variant 1
-		"Modified Argosy (Missile)" 2
+		"Modified Argosy" 2
 	variant 1
 		"Fury (Heavy)" 2
-		"Modified Argosy (Missile)"
+		"Modified Argosy"
 	variant 1
 		"Modified Argosy (Javelin)"
 		"Sparrow"
@@ -2101,7 +2101,7 @@ fleet "CCOR Logistics"
 	names "pirate"
 	cargo 1
 	personality
-		timid secretive coward appeasing
+		disables timid secretive coward appeasing
 	variant 1
 		"Hauler II"
 	variant 1
@@ -2183,7 +2183,7 @@ fleet "Large Independent"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Sparrow" 4
 	variant 5
@@ -2255,7 +2255,7 @@ fleet "Small Core Pirates"
 	variant 3
 		"Hawk"
 	variant 2
-		"Hawk (Rocket)"
+		"Hawk"
 	variant 2
 		"Hawk (Speedy)"
 	variant 1
@@ -2295,7 +2295,7 @@ fleet "Large Core Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests getaway
+		disables plunders harvests getaway
 	variant 5
 		"Quicksilver (Proton)" 3
 	variant 2
@@ -2307,19 +2307,19 @@ fleet "Large Core Pirates"
 		"Splinter (Laser)"
 		"Quicksilver"
 	variant 2
-		"Hawk (Bomber)"
+		"Hawk"
 		"Quicksilver" 2
 	variant 1
 		"Fury (Heavy)"
 		"Splinter"
 	variant 2
-		"Hawk (Bomber)"
+		"Hawk"
 		"Quicksilver (Proton)" 2
 	variant 3
-		"Fury (Bomber)"
+		"Fury"
 		"Quicksilver" 2
 	variant 3
-		"Fury (Bomber)"
+		"Fury"
 		"Quicksilver (Proton)" 2
 	variant 2
 		"Headhunter (Strike)"
@@ -2354,11 +2354,11 @@ fleet "Large Core Pirates"
 	variant 1
 		"Firebird (Plasma)"
 	variant 1
-		"Firebird (Missile)"
+		"Firebird"
 	variant 1
 		"Vanguard (Particle)"
 	variant 1
-		"Vanguard (Missile)"
+		"Vanguard"
 	variant 1
 		"Vanguard"
 	variant 1
@@ -2382,11 +2382,11 @@ fleet "Small Northern Pirates"
 	variant 3
 		"Fury"
 	variant 1
-		"Fury (Missile)"
+		"Fury"
 	variant 1
 		"Fury (Laser)"
 	variant 1
-		"Fury (Bomber)"
+		"Fury"
 	variant 1
 		"Fury (Heavy)"
 	variant 2
@@ -2398,11 +2398,11 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Hawk"
 	variant 1
-		"Hawk (Rocket)"
+		"Hawk"
 	variant 1
 		"Hawk (Speedy)"
 	variant 1
-		"Hawk (Bomber)"
+		"Hawk"
 		"Sparrow"
 	variant 1
 		"Aerie"
@@ -2423,7 +2423,7 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Corvette"
 	variant 1
-		"Corvette (Missile)"
+		"Corvette"
 	variant 1
 		"Corvette (Speedy)"
 	variant 1
@@ -2445,13 +2445,13 @@ fleet "Large Northern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests getaway
+		disables plunders harvests getaway
 	variant 4
 		"Firebird"
 	variant 10
 		"Firebird (Laser)"
 	variant 2
-		"Firebird (Missile)"
+		"Firebird"
 	variant 8
 		"Firebird (Plasma)"
 	variant 2
@@ -2462,10 +2462,10 @@ fleet "Large Northern Pirates"
 		"Corvette (Speedy)"
 	variant 4
 		"Firebird (Plasma)"
-		"Corvette (Missile)"
+		"Corvette"
 	variant 2
 		"Firebird (Laser)"
-		"Corvette (Missile)"
+		"Corvette"
 	variant 4
 		"Firebird"
 		"Fury"
@@ -2474,10 +2474,10 @@ fleet "Large Northern Pirates"
 		"Berserker" 2
 	variant 2
 		"Firebird (Plasma)"
-		"Fury (Missile)"
+		"Fury"
 	variant 2
-		"Firebird (Missile)"
-		"Fury (Bomber)"
+		"Firebird"
+		"Fury"
 	variant 6
 		"Raven (Afterburner)" 2
 	variant 2
@@ -2502,7 +2502,7 @@ fleet "Large Northern Pirates"
 	variant 4
 		"Aerie"
 		"Dagger" 2
-		"Corvette (Missile)"
+		"Corvette"
 	variant 2
 		"Aerie" 2
 		"Dagger" 4
@@ -2527,10 +2527,10 @@ fleet "Large Northern Pirates"
 		"Firebird (Plasma)"
 	variant 4
 		"Leviathan (Heavy)"
-		"Firebird (Missile)"
+		"Firebird"
 	variant 4
 		"Leviathan (Laser)"
-		"Firebird (Missile)"
+		"Firebird"
 	variant 6
 		"Leviathan"
 	variant 4
@@ -2539,7 +2539,7 @@ fleet "Large Northern Pirates"
 		"Leviathan (Heavy)"
 	variant 2
 		"Fury (Heavy)" 2
-		"Firebird (Missile)"
+		"Firebird"
 	variant 1
 		"Bactrian"
 		"Dagger" 3
@@ -2647,9 +2647,9 @@ fleet "pirate raid"
 		"Berserker" 2
 	variant 1
 		"Firebird (Plasma)"
-		"Fury (Missile)"
+		"Fury"
 	variant 1
-		"Firebird (Missile)"
+		"Firebird"
 		"Fury"
 	variant 8
 		"Raven (Afterburner)" 2
@@ -2659,7 +2659,7 @@ fleet "pirate raid"
 		"Headhunter (Particle)" 3
 	variant 1
 		"Fury (Heavy)" 2
-		"Firebird (Missile)"
+		"Firebird"
 	variant 2
 		"Leviathan"
 		"Firebird"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2055,7 +2055,7 @@ fleet "Large Southern Pirates"
 	variant 2
 		"Argosy (Laser)"
 	variant 2
-		"Argosy (Missile)"
+		"Argosy (Raider)"
 	variant 2
 		"Argosy (Turret)"
 	variant 1
@@ -2120,7 +2120,7 @@ fleet "Large Southern Pirates"
 		"Argosy (Turret)"
 		"Hawk (Speedy)"
 	variant 1
-		"Argosy (Missile)"
+		"Argosy (Raider)"
 		"Hawk (Raider)"
 	variant 1
 		"Modified Argosy"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1921,7 +1921,7 @@ fleet "Large Southern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests getaway
+		disables plunders harvests getaway
 	variant 2
 		"Sparrow" 4
 	variant 1
@@ -2101,7 +2101,7 @@ fleet "CCOR Logistics"
 	names "pirate"
 	cargo 1
 	personality
-		timid secretive coward appeasing
+		disables timid secretive coward appeasing
 	variant 1
 		"Hauler II"
 	variant 1
@@ -2295,7 +2295,7 @@ fleet "Large Core Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests getaway
+		disables plunders harvests getaway
 	variant 5
 		"Quicksilver (Proton)" 3
 	variant 2
@@ -2445,7 +2445,7 @@ fleet "Large Northern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		plunders harvests getaway
+		disables plunders harvests getaway
 	variant 4
 		"Firebird"
 	variant 10
@@ -2903,7 +2903,7 @@ fleet "Marauder I"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Marauder Arrow"
 	variant 1
@@ -2922,7 +2922,7 @@ fleet "Marauder II"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Marauder Quicksilver"
 	variant 1
@@ -2941,7 +2941,7 @@ fleet "Marauder III"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Marauder Firebird"
 	variant 1
@@ -2966,7 +2966,7 @@ fleet "Marauder IV"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Marauder Falcon"
 	variant 1
@@ -2985,7 +2985,7 @@ fleet "Marauder fleet I"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 9
 		"Marauder Quicksilver"
 		"Marauder Arrow (Weapons)"
@@ -3024,7 +3024,7 @@ fleet "Marauder fleet II"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 4
 		"Marauder Quicksilver"
 		"Marauder Arrow (Weapons)"
@@ -3063,7 +3063,7 @@ fleet "Marauder fleet III"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Marauder Quicksilver"
 		"Marauder Arrow (Weapons)"
@@ -3102,7 +3102,7 @@ fleet "Marauder fleet IV"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 8
 		"Marauder Firebird"
 		"Marauder Raven"
@@ -3145,7 +3145,7 @@ fleet "Marauder fleet V"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 4
 		"Marauder Firebird"
 		"Marauder Raven"
@@ -3188,7 +3188,7 @@ fleet "Marauder fleet VI"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 2
 		"Marauder Firebird"
 		"Marauder Raven"
@@ -3231,7 +3231,7 @@ fleet "Marauder fleet VII"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 18
 		"Marauder Falcon"
 		"Osprey"
@@ -3271,7 +3271,7 @@ fleet "Marauder fleet VIII"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 8
 		"Marauder Falcon"
 		"Osprey"
@@ -3308,7 +3308,7 @@ fleet "Marauder fleet IX"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Marauder Falcon"
 		"Osprey"
@@ -3349,7 +3349,7 @@ fleet "Marauder fleet X"
 	names "pirate"
 	cargo 1
 	personality
-		plunders
+		disables plunders
 	variant 3
 		"Marauder Falcon"
 		"Marauder Firebird"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2354,7 +2354,7 @@ fleet "Large Core Pirates"
 	variant 1
 		"Firebird (Plasma)"
 	variant 1
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 	variant 1
 		"Vanguard (Particle)"
 	variant 1
@@ -2451,7 +2451,7 @@ fleet "Large Northern Pirates"
 	variant 10
 		"Firebird (Laser)"
 	variant 2
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 	variant 8
 		"Firebird (Plasma)"
 	variant 2
@@ -2476,7 +2476,7 @@ fleet "Large Northern Pirates"
 		"Firebird (Plasma)"
 		"Fury (Raider Missile)"
 	variant 2
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 		"Fury (Raider)"
 	variant 6
 		"Raven (Afterburner)" 2
@@ -2527,10 +2527,10 @@ fleet "Large Northern Pirates"
 		"Firebird (Plasma)"
 	variant 4
 		"Leviathan (Heavy)"
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 	variant 4
 		"Leviathan (Laser)"
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 	variant 6
 		"Leviathan"
 	variant 4
@@ -2539,7 +2539,7 @@ fleet "Large Northern Pirates"
 		"Leviathan (Heavy)"
 	variant 2
 		"Fury (Heavy)" 2
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 	variant 1
 		"Bactrian"
 		"Dagger" 3
@@ -2649,7 +2649,7 @@ fleet "pirate raid"
 		"Firebird (Plasma)"
 		"Fury (Raider Missile)"
 	variant 1
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 		"Fury"
 	variant 8
 		"Raven (Afterburner)" 2
@@ -2659,7 +2659,7 @@ fleet "pirate raid"
 		"Headhunter (Particle)" 3
 	variant 1
 		"Fury (Heavy)" 2
-		"Firebird (Missile)"
+		"Firebird (Raider)"
 	variant 2
 		"Leviathan"
 		"Firebird"

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -2423,7 +2423,7 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Corvette"
 	variant 1
-		"Corvette (Missile)"
+		"Corvette (Raider)"
 	variant 1
 		"Corvette (Speedy)"
 	variant 1
@@ -2462,10 +2462,10 @@ fleet "Large Northern Pirates"
 		"Corvette (Speedy)"
 	variant 4
 		"Firebird (Plasma)"
-		"Corvette (Missile)"
+		"Corvette (Raider)"
 	variant 2
 		"Firebird (Laser)"
-		"Corvette (Missile)"
+		"Corvette (Raider)"
 	variant 4
 		"Firebird"
 		"Fury"
@@ -2502,7 +2502,7 @@ fleet "Large Northern Pirates"
 	variant 4
 		"Aerie"
 		"Dagger" 2
-		"Corvette (Missile)"
+		"Corvette (Raider)"
 	variant 2
 		"Aerie" 2
 		"Dagger" 4

--- a/data/human/fleets.txt
+++ b/data/human/fleets.txt
@@ -1842,17 +1842,17 @@ fleet "Small Southern Pirates"
 	variant 2
 		"Hawk (Speedy)"
 	variant 2
-		"Hawk"
+		"Hawk (Rocket)"
 	variant 5
 		"Fury"
 	variant 4
-		"Fury"
+		"Fury (Bomber)"
 	variant 1
 		"Fury (Laser)"
 	variant 1
 		"Fury (Gatling)"
 	variant 1
-		"Fury"
+		"Fury (Missile)"
 	variant 1
 		"Fury (Heavy)"
 	variant 4
@@ -1866,7 +1866,7 @@ fleet "Small Southern Pirates"
 	variant 1
 		"Fury" 3
 	variant 1
-		"Fury" 2
+		"Fury (Missile)" 2
 	variant 1
 		"Fury (Heavy)" 2
 	variant 1
@@ -1877,13 +1877,13 @@ fleet "Small Southern Pirates"
 		"Fury"
 		"Sparrow"
 	variant 1
-		"Hawk"
-		"Fury"
+		"Hawk (Rocket)"
+		"Fury (Missile)"
 		"Sparrow"
 	variant 1
 		"Sparrow" 3
 	variant 1
-		"Fury"
+		"Fury (Bomber)"
 		"Sparrow"
 	variant 1
 		"Hawk" 2
@@ -1892,7 +1892,7 @@ fleet "Small Southern Pirates"
 	variant 2
 		"Clipper"
 	variant 1
-		"Clipper"
+		"Clipper (Heavy)"
 	variant 1
 		"Clipper (Speedy)"
 	variant 1
@@ -1921,7 +1921,7 @@ fleet "Large Southern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		disables plunders harvests getaway
+		plunders harvests getaway
 	variant 2
 		"Sparrow" 4
 	variant 1
@@ -1933,7 +1933,7 @@ fleet "Large Southern Pirates"
 	variant 2
 		"Argosy (Laser)"
 	variant 2
-		"Argosy"
+		"Argosy (Missile)"
 	variant 2
 		"Argosy (Turret)"
 	variant 1
@@ -1943,7 +1943,7 @@ fleet "Large Southern Pirates"
 	variant 1
 		"Modified Argosy (Blaster)"
 	variant 1
-		"Modified Argosy"
+		"Modified Argosy (Missile)"
 	variant 1
 		"Modified Argosy (Javelin)"
 	variant 1
@@ -1951,7 +1951,7 @@ fleet "Large Southern Pirates"
 	variant 4
 		"Clipper"
 	variant 2
-		"Clipper"
+		"Clipper (Heavy)"
 	variant 2
 		"Clipper (Speedy)"
 	variant 1
@@ -1961,36 +1961,36 @@ fleet "Large Southern Pirates"
 		"Osprey"
 		"Sparrow"
 	variant 1
-		"Osprey"
+		"Osprey (Missile)"
 	variant 1
 		"Osprey (Laser)"
 	variant 2
 		"Clipper"
 		"Hawk"
 	variant 1
-		"Clipper"
-		"Hawk"
+		"Clipper (Heavy)"
+		"Hawk (Rocket)"
 	variant 2
-		"Hawk"
+		"Hawk (Bomber)"
 		"Sparrow" 3
 	variant 2
-		"Fury"
+		"Fury (Bomber)"
 		"Sparrow" 3
 	variant 1
 		"Clipper (Speedy)"
 		"Hawk (Speedy)"
 	variant 1
-		"Hawk"
+		"Hawk (Bomber)"
 		"Fury (Gatling)" 2
 	variant 1
-		"Fury"
+		"Fury (Bomber)"
 		"Fury (Gatling)" 2
 	variant 3
 		"Argosy"
 		"Hawk"
 	variant 1
 		"Argosy (Blaster)"
-		"Hawk"
+		"Hawk (Rocket)"
 	variant 1
 		"Argosy (Laser)"
 		"Hawk (Speedy)"
@@ -1998,8 +1998,8 @@ fleet "Large Southern Pirates"
 		"Argosy (Turret)"
 		"Hawk (Speedy)"
 	variant 1
-		"Argosy"
-		"Hawk"
+		"Argosy (Missile)"
+		"Hawk (Rocket)"
 	variant 1
 		"Modified Argosy"
 		"Sparrow" 2
@@ -2010,10 +2010,10 @@ fleet "Large Southern Pirates"
 		"Modified Argosy (Blaster)"
 		"Sparrow" 2
 	variant 1
-		"Modified Argosy" 2
+		"Modified Argosy (Missile)" 2
 	variant 1
 		"Fury (Heavy)" 2
-		"Modified Argosy"
+		"Modified Argosy (Missile)"
 	variant 1
 		"Modified Argosy (Javelin)"
 		"Sparrow"
@@ -2101,7 +2101,7 @@ fleet "CCOR Logistics"
 	names "pirate"
 	cargo 1
 	personality
-		disables timid secretive coward appeasing
+		timid secretive coward appeasing
 	variant 1
 		"Hauler II"
 	variant 1
@@ -2183,7 +2183,7 @@ fleet "Large Independent"
 	names "pirate"
 	cargo 1
 	personality
-		disables plunders
+		plunders
 	variant 3
 		"Sparrow" 4
 	variant 5
@@ -2255,7 +2255,7 @@ fleet "Small Core Pirates"
 	variant 3
 		"Hawk"
 	variant 2
-		"Hawk"
+		"Hawk (Rocket)"
 	variant 2
 		"Hawk (Speedy)"
 	variant 1
@@ -2295,7 +2295,7 @@ fleet "Large Core Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		disables plunders harvests getaway
+		plunders harvests getaway
 	variant 5
 		"Quicksilver (Proton)" 3
 	variant 2
@@ -2307,19 +2307,19 @@ fleet "Large Core Pirates"
 		"Splinter (Laser)"
 		"Quicksilver"
 	variant 2
-		"Hawk"
+		"Hawk (Bomber)"
 		"Quicksilver" 2
 	variant 1
 		"Fury (Heavy)"
 		"Splinter"
 	variant 2
-		"Hawk"
+		"Hawk (Bomber)"
 		"Quicksilver (Proton)" 2
 	variant 3
-		"Fury"
+		"Fury (Bomber)"
 		"Quicksilver" 2
 	variant 3
-		"Fury"
+		"Fury (Bomber)"
 		"Quicksilver (Proton)" 2
 	variant 2
 		"Headhunter (Strike)"
@@ -2354,11 +2354,11 @@ fleet "Large Core Pirates"
 	variant 1
 		"Firebird (Plasma)"
 	variant 1
-		"Firebird"
+		"Firebird (Missile)"
 	variant 1
 		"Vanguard (Particle)"
 	variant 1
-		"Vanguard"
+		"Vanguard (Missile)"
 	variant 1
 		"Vanguard"
 	variant 1
@@ -2382,11 +2382,11 @@ fleet "Small Northern Pirates"
 	variant 3
 		"Fury"
 	variant 1
-		"Fury"
+		"Fury (Missile)"
 	variant 1
 		"Fury (Laser)"
 	variant 1
-		"Fury"
+		"Fury (Bomber)"
 	variant 1
 		"Fury (Heavy)"
 	variant 2
@@ -2398,11 +2398,11 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Hawk"
 	variant 1
-		"Hawk"
+		"Hawk (Rocket)"
 	variant 1
 		"Hawk (Speedy)"
 	variant 1
-		"Hawk"
+		"Hawk (Bomber)"
 		"Sparrow"
 	variant 1
 		"Aerie"
@@ -2423,7 +2423,7 @@ fleet "Small Northern Pirates"
 	variant 2
 		"Corvette"
 	variant 1
-		"Corvette"
+		"Corvette (Missile)"
 	variant 1
 		"Corvette (Speedy)"
 	variant 1
@@ -2445,13 +2445,13 @@ fleet "Large Northern Pirates"
 	names "pirate"
 	cargo 1
 	personality
-		disables plunders harvests getaway
+		plunders harvests getaway
 	variant 4
 		"Firebird"
 	variant 10
 		"Firebird (Laser)"
 	variant 2
-		"Firebird"
+		"Firebird (Missile)"
 	variant 8
 		"Firebird (Plasma)"
 	variant 2
@@ -2462,10 +2462,10 @@ fleet "Large Northern Pirates"
 		"Corvette (Speedy)"
 	variant 4
 		"Firebird (Plasma)"
-		"Corvette"
+		"Corvette (Missile)"
 	variant 2
 		"Firebird (Laser)"
-		"Corvette"
+		"Corvette (Missile)"
 	variant 4
 		"Firebird"
 		"Fury"
@@ -2474,10 +2474,10 @@ fleet "Large Northern Pirates"
 		"Berserker" 2
 	variant 2
 		"Firebird (Plasma)"
-		"Fury"
+		"Fury (Missile)"
 	variant 2
-		"Firebird"
-		"Fury"
+		"Firebird (Missile)"
+		"Fury (Bomber)"
 	variant 6
 		"Raven (Afterburner)" 2
 	variant 2
@@ -2502,7 +2502,7 @@ fleet "Large Northern Pirates"
 	variant 4
 		"Aerie"
 		"Dagger" 2
-		"Corvette"
+		"Corvette (Missile)"
 	variant 2
 		"Aerie" 2
 		"Dagger" 4
@@ -2527,10 +2527,10 @@ fleet "Large Northern Pirates"
 		"Firebird (Plasma)"
 	variant 4
 		"Leviathan (Heavy)"
-		"Firebird"
+		"Firebird (Missile)"
 	variant 4
 		"Leviathan (Laser)"
-		"Firebird"
+		"Firebird (Missile)"
 	variant 6
 		"Leviathan"
 	variant 4
@@ -2539,7 +2539,7 @@ fleet "Large Northern Pirates"
 		"Leviathan (Heavy)"
 	variant 2
 		"Fury (Heavy)" 2
-		"Firebird"
+		"Firebird (Missile)"
 	variant 1
 		"Bactrian"
 		"Dagger" 3
@@ -2647,9 +2647,9 @@ fleet "pirate raid"
 		"Berserker" 2
 	variant 1
 		"Firebird (Plasma)"
-		"Fury"
+		"Fury (Missile)"
 	variant 1
-		"Firebird"
+		"Firebird (Missile)"
 		"Fury"
 	variant 8
 		"Raven (Afterburner)" 2
@@ -2659,7 +2659,7 @@ fleet "pirate raid"
 		"Headhunter (Particle)" 3
 	variant 1
 		"Fury (Heavy)" 2
-		"Firebird"
+		"Firebird (Missile)"
 	variant 2
 		"Leviathan"
 		"Firebird"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1291,10 +1291,10 @@ ship "Corvette" "Corvette (Raider)"
 	gun
 	pylon "Meteor Missile Launcher"
 	pylon "Torpedo Pod"
-	pylon "Torpedo Launcher"
-	pylon "Torpedo Launcher"
+	pylon
+	pylon
 	turret "Anti-Missile Turret"
-	turret "Heavy Anti-Missile Turret"
+	turret "Heavy Laser Turret"
 
 
 ship "Corvette" "Corvette (Speedy)"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1028,6 +1028,24 @@ ship "Clipper" "Clipper (Nuclear)"
 		"Volcano Afterburner"
 
 
+ship "Clipper" "Clipper (Raider)"
+	outfits
+		"Plasma Cannon" 2
+		"Energy Blaster" 2
+		"LP072a Battery Pack"
+		"KP-6 Photovoltaic Array" 3
+		"nGVF-CC Fuel Cell"
+		"Cargo Expansion"
+		"Interference Plating" 2
+		"D14-RN Shield Generator"
+		"Rangefinder Scanner"
+		"Greyhound Plasma Steering"
+		"Greyhound Plasma Thruster"
+		"Volcano Afterburner"
+		Hyperdrive
+
+
+
 ship "Clipper" "Clipper (Speedy)"
 	outfits
 		"Heavy Laser" 4
@@ -2235,6 +2253,35 @@ ship "Fury" "Fury (Missile)"
 		"Hyperdrive"
 
 
+ship "Fury" "Fury (Raider)"
+	outfits
+		"Modified Blaster" 4
+		"KP-6 Photovoltaic Array"
+		"LP072a Battery Pack"
+		"D14-RN Shield Generator"
+		"Cargo Expansion"
+		"Chipmunk Plasma Steering"
+		"Chipmunk Plasma Thruster"
+		"Volcano Afterburner"
+		Hyperdrive
+
+
+ship "Fury" "Fury (Raider Missile)"
+	outfits
+		"Modified Blaster" 4
+		"Javelin Mini Pod"
+		Javelin 30
+		"Meteor Missile Pod"
+		"Meteor Missile" 7
+		"KP-6 Photovoltaic Array"
+		"LP072a Battery Pack"
+		"Cargo Expansion"
+		"Chipmunk Plasma Steering"
+		"Chipmunk Plasma Thruster"
+		"Volcano Afterburner"
+		Hyperdrive
+
+
 ship "Fury" "Fury (Thermal Scanner)"
 	outfits
 		"Energy Blaster" 2
@@ -2401,6 +2448,21 @@ ship "Hawk" "Hawk (Plasma)"
 		"X2700 Ion Thruster"
 		"Greyhound Plasma Steering"
 		"Hyperdrive"
+
+
+ship "Hawk" "Hawk (Raider)"
+	outfits
+		"Beam Laser" 2
+		"KP-6 Photovoltaic Panel" 4
+		"LP072a Battery Pack"
+		"nGVF-AA Fuel Cell"
+		"Cargo Expansion"
+		"Small Radar Jammer"
+		"D23-QP Shield Generator"
+		"Volcano Afterburner"
+		"Greyhound Plasma Steering"
+		"Greyhound Plasma Thruster"
+		Hyperdrive
 
 
 ship "Hawk" "Hawk (Rocket)"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1261,6 +1261,42 @@ ship "Corvette" "Corvette (Missile)"
 	turret "Heavy Anti-Missile Turret"
 
 
+ship "Corvette" "Corvette (Raider)"
+	outfits
+		"Energy Blaster" 4
+		"Torpedo Pod"
+		Torpedo 3
+		"Meteor Missile Launcher"
+		"Meteor Missile" 30
+		"Heavy Laser Turret"
+		"Anti-Missile Turret"
+		"KP-6 Photovoltaic Array"
+		"LP072a Battery Pack"
+		"nGVF-CC Fuel Cell"
+		"D23-QP Shield Generator"
+		"Large Radar Jammer"
+		"Cargo Expansion" 3
+		"Cargo Scanner" 2
+		"Interference Plating" 2
+		"Fuel Pod" 2
+		"Laser Rifle" 3
+		"Water Coolant System"
+		"X3200 Ion Steering"
+		"X3700 Ion Thruster"
+		"Volcano Afterburner"
+		Hyperdrive
+	gun
+	gun
+	gun
+	gun
+	pylon "Meteor Missile Launcher"
+	pylon "Torpedo Pod"
+	pylon "Torpedo Launcher"
+	pylon "Torpedo Launcher"
+	turret "Anti-Missile Turret"
+	turret "Heavy Anti-Missile Turret"
+
+
 ship "Corvette" "Corvette (Speedy)"
 	outfits
 		"Particle Cannon" 4

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1033,11 +1033,11 @@ ship "Clipper" "Clipper (Raider)"
 		"Plasma Cannon" 2
 		"Energy Blaster" 2
 		"LP072a Battery Pack"
-		"KP-6 Photovoltaic Array" 3
+		"KP-6 Photovoltaic Panel" 3
 		"nGVF-CC Fuel Cell"
-		"Cargo Expansion"
-		"Interference Plating" 2
 		"D14-RN Shield Generator"
+		"Interference Plating" 2
+		"Cargo Expansion"
 		"Rangefinder Scanner"
 		"Greyhound Plasma Steering"
 		"Greyhound Plasma Thruster"

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -99,6 +99,23 @@ ship "Argosy" "Argosy (Proton)"
 		"Hyperdrive"
 
 
+ship "Argosy" "Argosy (Raider)"
+	outfits
+		"Energy Blaster" 4
+		"Meteor Missile Pod" 2
+		"Meteor Missile" 14
+		"Blaster Turret"
+		"Tractor Beam"
+		"D14-RN Shield Generator"
+		"Cargo Expansion"
+		"LP072a Battery Pack"
+		"nGVF-BB Fuel Cell"
+		"Capybara Reverse Thruster"
+		"X3200 Ion Steering"
+		"Greyhound Plasma Thruster"
+		Hyperdrive
+
+
 ship "Argosy" "Argosy (Turret)"
 	outfits
 		"Heavy Laser Turret" 2

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -1920,6 +1920,35 @@ ship "Firebird" "Firebird (Plasma)"
 		"Hyperdrive"
 
 
+ship "Firebird" "Firebird (Raider)"
+	outfits
+		"Plasma Cannon" 4
+		"Meteor Missile Pod" 2
+		"Meteor Missile" 14
+		"Quad Blaster Turret"
+		"Anti-Missile Turret"
+		"Cargo Expansion" 2
+		"Cargo Scanner" 2
+		"D14-RN Shield Generator"
+		"LP144a Battery Pack"
+		"RT-I Radiothermal"
+		"Laser Rifle" 3
+		"X3200 Ion Steering"
+		"X3700 Ion Thruster"
+		"Volcano Afterburner"
+		Hyperdrive
+	gun
+	gun
+	gun
+	gun
+	pylon "Meteor Missile Pod"
+	pylon "Meteor Missile Pod"
+	pylon
+	pylon
+	turret "Quad Blaster Turret"
+	turret "Anti-Missile Turret"
+
+
 ship "Firebird" "Firebird (CCOR)"
 	outfits
 		"Twin Modified Blaster" 4


### PR DESCRIPTION
## Issue

Pirates are, shall we say, not designed very well:
- They frequently overly utilized missiles, rockets, and ordinance that is noted for making it *harder* to disable and loot.
- This overuse of missiles, rockets, and ordinance also add significant costs and thus impacting their budget.
- They frequently kill new players
- They appear to be built to punch as far above their weight as possible. As in they appear to be designed to target things *bigger* than them, and particularly appears to be designed specifically to target and take on military ships. 

All combined, they result in a faction that doesn't make sense, doesn't fit the lore, and makes for a bad game experience.

## Resolution

"Disables" has been added to all pirate fleets that didn't already have it.

Within the Pirate specific fleets, WIP:
- [x] Most missile and rocket focused variants have been replaced with a version of that ship optimized for looting. These may still have missiles or rockets, they just aren't exclusively focused on them anymore.
- [x] The clipper (heavy) variant has been replaced by a clipper optimized for running.

Note 1: This does not remove missiles and other projectiles from pirate fleets. It just replaces the variant ships that are heavily focused on missile weaponry. The focus is on small fleets, which are the ones most likely to be encountered and/or triggered by newer and smaller players.

NOTE 2: The "Pirate (Explosive)" fleet has been left untouched, as that fleet appears specifically designed around high explosive ordinance use.

NOTE 3: While the Marauder pirates have been given "disables", they haven't otherwise been touched. Marauder ships are their own kettle of fish to be dealt with separately, since they're most typically job fleets, not randoms.