### PR TITLE
Feat(fix): Donya sprite typo

### DIFF
--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -30222,7 +30222,7 @@ system Sabik
 		distance 1424.5
 		period 513.620
 	object Donya
-		sprite planet/clouds0
+		sprite planet/cloud0
 		distance 1280.19
 		period 732.877
 	object


### PR DESCRIPTION
**Typo fix**

This PR addresses a bug with issue #131.

## Summary
 
Donya is not showing up in Sabik due to a sprite typo. 

Changes the sprite for Donya from `planet/clouds0` to `planet/cloud0`

## Screenshots
Before:
<img width="400" alt="Screenshot 2024-12-03 at 6 10 06 AM" src="https://github.com/user-attachments/assets/51b3d67f-38d7-495e-b27d-029cee3bd41b">

After: 
<img width="400" alt="Screenshot 2024-12-03 at 6 12 21 AM" src="https://github.com/user-attachments/assets/45cf8d27-10bb-4434-a8dd-1d718866a56a">
