### PR TITLE
feat(fix): Fixing the Settings panel alignment

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -479,9 +479,7 @@ interface "load menu"
 
 interface "controls"
 	sprite "ui/keys panel"
-		center -25 -20
-	sprite "ui/shift panel"
-		center -346 56
+		center -65 -20
 	button c "_Controls"
 		center -300 -230
 		dimensions 90 30


### PR DESCRIPTION
This is more or less undoing the adjustment to the alignment that happened a long time ago to make the shift panel properly floating. It's no longer used in the same way, though, so the shift panel doesn't need to be referenced here anymore, and the settings panel as a whole needs to be move over a bit to match the text properly.