### PR TITLE
feat(c): Starry Map cleanup

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -2039,19 +2039,6 @@ interface "map buttons" bottom right
 		from -50 -90 to -80 -120
 		size 18
 
-	sprite "ui/map display"
-		from 0 -120 to -49 -169
-	button x ""
-		from 0 -120 to -49 -169
-	visible if "map is starry"
-	ring "system ring"
-		center -24 -145
-		dimensions 10 10
-		color "map system ring"
-		size 2
-	visible if "!map is starry"
-	sprite "ui/star icon"
-		from 0 -120 to -49 -169
 
 
 interface "map buttons (small screen)" bottom right
@@ -2108,19 +2095,6 @@ interface "map buttons (small screen)" bottom right
 		from -50 -90 to -80 -120
 		size 18
 
-	sprite "ui/map display"
-		from 0 -120 to -49 -169
-	button x ""
-		from 0 -120 to -49 -169
-	visible if "map is starry"
-	ring "system ring"
-		center -24 -145
-		dimensions 10 10
-		color "map system ring"
-		size 2
-	visible if "!map is starry"
-	sprite "ui/star icon"
-		from 0 -120 to -49 -169
 
 
 interface "map"

--- a/source/MapPanel.cpp
+++ b/source/MapPanel.cpp
@@ -375,12 +375,6 @@ void MapPanel::FinishDrawing(const string &buttonCondition)
 		info.SetCondition("max zoom");
 	if(player.MapZoom() <= static_cast<int>(mapInterface->GetValue("min zoom")))
 		info.SetCondition("min zoom");
-	mapIsStarry = player.StarryMap();
-	if(mapIsStarry)
-	{
-		info.SetCondition("map is starry");
-		info.SetBar("system ring", 1.);
-	}
 	const Interface *mapButtonUi = GameData::Interfaces().Get(Screen::Width() < 1280
 		? "map buttons (small screen)" : "map buttons");
 	mapButtonUi->Draw(info, this);
@@ -622,8 +616,6 @@ bool MapPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool
 			this, &MapPanel::Find, "Search for:", "", Truncate::NONE, true));
 		return true;
 	}
-	else if(key == 'x')
-		player.SetStarryMap(!mapIsStarry);
 	else if(key == SDLK_PLUS || key == SDLK_KP_PLUS || key == SDLK_EQUALS)
 		player.SetMapZoom(min<int>(mapInterface->GetValue("max zoom"), player.MapZoom() + 1));
 	else if(key == SDLK_MINUS || key == SDLK_KP_MINUS)

--- a/source/MapPanel.h
+++ b/source/MapPanel.h
@@ -145,7 +145,6 @@ protected:
 	int recentering = 0;
 	int commodity;
 	int step = 0;
-	bool mapIsStarry = false;
 	std::string buttonCondition;
 
 	// Distance from the screen center to the nearest owned system,

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -263,8 +263,6 @@ void PlayerInfo::Load(const filesystem::path &path)
 			mapColoring = child.Value(1);
 		else if(child.Token(0) == "map zoom" && child.Size() >= 2)
 			mapZoom = child.Value(1);
-		else if(child.Token(0) == "starry map" && child.Size() >= 2)
-			isStarry = child.Value(1);
 		else if(child.Token(0) == "collapsed" && child.Size() >= 2)
 		{
 			for(const DataNode &grand : child)
@@ -3009,6 +3007,7 @@ void PlayerInfo::Harvest(const Outfit *type)
 
 
 const set<pair<const System *, const Outfit *>> &PlayerInfo::Harvested() const
+
 {
 	return harvested;
 }
@@ -3067,22 +3066,6 @@ int PlayerInfo::MapZoom() const
 void PlayerInfo::SetMapZoom(int level)
 {
 	mapZoom = level;
-}
-
-
-
-// Get the map display mode.
-bool PlayerInfo::StarryMap() const
-{
-	return isStarry;
-}
-
-
-
-// Set the map display mode.
-void PlayerInfo::SetStarryMap(bool state)
-{
-	isStarry = state;
 }
 
 
@@ -4396,7 +4379,6 @@ void PlayerInfo::Save(DataWriter &out) const
 	// Save the current setting for the map coloring;
 	out.Write("map coloring", mapColoring);
 	out.Write("map zoom", mapZoom);
-	out.Write("starry map", isStarry);
 	// Remember what categories are collapsed.
 	for(const auto &it : collapsed)
 	{

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3007,7 +3007,6 @@ void PlayerInfo::Harvest(const Outfit *type)
 
 
 const set<pair<const System *, const Outfit *>> &PlayerInfo::Harvested() const
-
 {
 	return harvested;
 }

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -341,9 +341,6 @@ public:
 	// Get or set the map zoom level.
 	int MapZoom() const;
 	void SetMapZoom(int level);
-	// Get or set the map display mode.
-	bool StarryMap() const;
-	void SetStarryMap(bool state);
 	// Get the set of collapsed categories for the named panel.
 	std::set<std::string> &Collapsed(const std::string &name);
 	// Should help dialogs relating to carriers be displayed?
@@ -473,7 +470,6 @@ private:
 	// Currently selected coloring, in the map panel (defaults to reputation):
 	int mapColoring = -6;
 	int mapZoom = 0;
-	bool isStarry = false;
 
 	// Currently collapsed categories for various panels.
 	std::map<std::string, std::set<std::string>> collapsed;


### PR DESCRIPTION
## Summary
Delta had Starry Maps long before Upstream did, based on the highly convenient star button that just replaced the system rings across the map. It looked beautiful. 

Upstream finally merged Starry Maps, however, in a somewhat different form, namely a separate stand-alone map layer. 

Personally, I found the first way just as easy and a bit prettier at that; but having stars as an actual map layer opens up the possibilities of having all sorts of other stuff happening. Talking with Azure3141 (author of Starry maps, both versions), they've got some ideas for this, although no timeline.

Ideas (not implemented here, just documenting them):
- Have info panels similar to the ones for planets but for the stars. (solar wind and solar power info)
- Have the listings for mineables found in a system to be shown here.
- Information about governments that are typically present.
- Information about system hazards.
- System "security" and "safety" ratings. (security is how strong and diligent the local security forces are, how much they scan, etc. Safety is how likely you, specifically, are to be attacked while in the system. So a system with a strong security presence of a faction you are hostile with might have a high security but low safety rating)

Given the potential for new functionality, I'm cleaning out the old and no longer functional aspects.
