### PR TITLE
feat(fix): Fixing Lateral Thruster usage

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -1853,7 +1853,11 @@ void AI::MoveIndependent(Ship &ship, Command &command) const
 			{
 				MoveTo(ship, command, Point(), Point(), 40., .8);
 				if(ship.Velocity().Dot(ship.Position()) > 0.)
+				{
 					command.SetThrust(1.);
+					double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
+					command.SetLateralThrust(deviation * 5);
+				}
 				return;
 			}
 		}
@@ -2449,11 +2453,18 @@ bool AI::MoveTo(Ship &ship, Command &command, const Point &targetPosition,
 	double maxVelocity = ship.MaxVelocity(ShouldUseAfterburner(ship)) * .99;
 	if(isFacing && (velocity.LengthSquared() <= maxVelocity * maxVelocity
 			|| dp.Unit().Dot(velocity.Unit()) < .95))
+	{
 		command.SetThrust(1.);
+		double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
+		command.SetLateralThrust(deviation * 5);
+	}
+
 	else if(shouldReverse)
 	{
 		command.SetTurn(TurnToward(ship, velocity));
 		command.SetThrust(-1.);
+		double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
+		command.SetLateralThrust(deviation * 5);
 	}
 
 	return false;
@@ -2513,14 +2524,22 @@ bool AI::Stop(Ship &ship, Command &command, double maxSpeed, const Point directi
 		{
 			command.SetTurn(TurnToward(ship, velocity));
 			if(velocity.Unit().Dot(angle.Unit()) > limit)
+			{
 				command.SetThrust(-1.);
+				double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
+				command.SetLateralThrust(deviation * 5);
+			}
 			return false;
 		}
 	}
 
 	command.SetTurn(TurnBackward(ship));
 	if(velocity.Unit().Dot(angle.Unit()) < -limit)
+	{
 		command.SetThrust(1.);
+		double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
+		command.SetLateralThrust(deviation * 5);
+	}
 
 	return false;
 }
@@ -2704,6 +2723,8 @@ void AI::KeepStation(Ship &ship, Command &command, const Body &target)
 		if(direction > THRUST_DEADBAND)
 		{
 			command.SetThrust(-1.);
+			double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
+			command.SetLateralThrust(deviation * 5);
 			return;
 		}
 	}
@@ -2711,7 +2732,11 @@ void AI::KeepStation(Ship &ship, Command &command, const Body &target)
 	double direction = positionWeight * positionDelta.Dot(a) / POSITION_DEADBAND
 		+ velocityWeight * velocityDelta.Dot(a) / VELOCITY_DEADBAND;
 	if(direction > THRUST_DEADBAND)
+	{
 		command.SetThrust(1.);
+		double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
+		command.SetLateralThrust(deviation * 5);
+	}
 }
 
 

--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -4625,7 +4625,8 @@ void AI::MovePlayer(Ship &ship, Command &activeCommands)
 		}
 
 		// Stability control, uses lateral thrusters instead of ship applying drag.
-		bool stabilityEngage = !shift && Preferences::Has("Disable auto-stabilization");
+		bool stabilityEngage = (!shift && Preferences::Has("Disable auto-stabilization"))
+			|| (shift && !Preferences::Has("Disable auto-stabilization"));
 		double deviation = ship.Velocity().Unit().Cross(ship.Facing().Unit());
 		if(shipThrusting && !stabilityEngage && !ShipLateralThrusting)
 			command.SetLateralThrust(deviation * 5);

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -5298,6 +5298,16 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 			latRatioTurnHeat = latRatioTurn * attributes.Get("turn heat");
 		}
 
+		if(!latThrustCommand)
+		{
+			double deviation = Velocity().Unit().Cross(angle.Unit());
+			bool facing = angle.Unit().Dot(velocity.Unit()) > -.5;
+			if(deviation < -0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
+				latThrustCommand = -1.;
+			else if(deviation > 0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
+				latThrustCommand = 1.;
+		}
+
 		if(latThrustCommand)
 		{
 			// Check if we are able to apply this thrust.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -5297,6 +5297,7 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 			latRatioTurnEnergy = latRatioTurn * attributes.Get("turn energy");
 			latRatioTurnHeat = latRatioTurn * attributes.Get("turn heat");
 		}
+
 		if(latThrustCommand)
 		{
 			// Check if we are able to apply this thrust.

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -5298,15 +5298,15 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 			latRatioTurnHeat = latRatioTurn * attributes.Get("turn heat");
 		}
 
-		if(!latThrustCommand)
-		{
-			double deviation = Velocity().Unit().Cross(angle.Unit());
-			bool facing = angle.Unit().Dot(velocity.Unit()) > -.5;
-			if(deviation < -0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
-				latThrustCommand = -1.;
-			else if(deviation > 0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
-				latThrustCommand = 1.;
-		}
+		//if(!latThrustCommand)
+		//{
+		//	double deviation = Velocity().Unit().Cross(angle.Unit());
+		//	bool facing = angle.Unit().Dot(velocity.Unit()) > -.5;
+		//	if(deviation < -0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
+		//		latThrustCommand = -1.;
+		//	else if(deviation > 0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
+		//		latThrustCommand = 1.;
+		//}
 
 		if(latThrustCommand)
 		{

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -5297,17 +5297,6 @@ void Ship::DoMovement(bool &isUsingAfterburner)
 			latRatioTurnEnergy = latRatioTurn * attributes.Get("turn energy");
 			latRatioTurnHeat = latRatioTurn * attributes.Get("turn heat");
 		}
-
-		//if(!latThrustCommand)
-		//{
-		//	double deviation = Velocity().Unit().Cross(angle.Unit());
-		//	bool facing = angle.Unit().Dot(velocity.Unit()) > -.5;
-		//	if(deviation < -0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
-		//		latThrustCommand = -1.;
-		//	else if(deviation > 0.01 && thrustMagnitude && !commands.Has(Command::SHIFT) && facing)
-		//		latThrustCommand = 1.;
-		//}
-
 		if(latThrustCommand)
 		{
 			// Check if we are able to apply this thrust.


### PR DESCRIPTION
**Bug fix**
For some reason, although it was working a while ago, the lateral thrusters aren't being used properly. This aims to fix that.

## Summary
1. This adds lateral thruster usage to a whole variety of NPC move actions so they stabilize their flight in most situations.
2. This expands the shift-key functionality when used with forward thrust. If "disable auto-stabilization" is on, then holding shift while forward thrusting will enable stabilization for as long as the two keys are held. If "disable auto-stabilization" is off, then holding shift while forward thrusting will disable stabilization for as long as the two are held. Basically, holding shift will flip whether or not stabilization happens while forward thrusting temporarily.

## Testing Done
Playing the game.