### PR TITLE
Feat(data): Removing forced universal reverse thruster

### DIFF
--- a/data/_deprecated/deprecated outfits.txt
+++ b/data/_deprecated/deprecated outfits.txt
@@ -69,11 +69,6 @@ outfit "Korath Ark'torbal Thruster"
 	"flare sprite" "effect/plasma flare/tiny"
 		"frame rate" 5
 	"flare sound" "plasma tiny"
-	"reverse thrust" 8.9
-	"reverse thrusting energy" 0.11
-	"reverse thrusting heat" 0.1
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
 	"reverse flare sound" "plasma tiny"
 	description "This engine is used by Korath fighters."
 
@@ -105,12 +100,6 @@ outfit "Korath Jak'torbal Thruster"
 	"flare sprite" "effect/plasma flare/large"
 		"frame rate" 8
 	"flare sound" "plasma large"
-	"reverse thrust" 6.31
-	"reverse thrusting energy" 0.59
-	"reverse thrusting heat" 1.43
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "plasma tiny"
 	description "This engine is used in the Korath capital ships."
 
 outfit "Korath Jak'parat Steering"

--- a/data/bunrodea/bunrodea outfits.txt
+++ b/data/bunrodea/bunrodea outfits.txt
@@ -236,14 +236,6 @@ outfit "Chiisana Rift Thruster"
 		"rewind"
 		"scale" 0.3
 	"flare sound" "ion tiny"
-	"reverse thrust" 1.1
-	"reverse thrusting energy" 0.115
-	"reverse thrusting heat" 0.065
-	"reverse flare sprite" "effect/bunrodea flare/large"
-		"frame rate" 1
-		"rewind"
-		"scale" 0.1
-	"reverse flare sound" "ion tiny"
 	description "While the Korath favor raw power in their engines, the Bunrodea favor efficiency, opting to make use of engines that produce less thrust for significantly less heat produced."
 
 outfit "Nami Rift Thruster"
@@ -263,14 +255,6 @@ outfit "Nami Rift Thruster"
 		"rewind"
 		"scale" 0.6
 	"flare sound" "ion small"
-	"reverse thrust" 2.1
-	"reverse thrusting energy" 0.23
-	"reverse thrusting heat" 0.13
-	"reverse flare sprite" "effect/bunrodea flare/large"
-		"frame rate" 1
-		"rewind"
-		"scale" 0.2
-	"reverse flare sound" "ion tiny"
 	description "Although rift engines are extremely heat efficient, their energy requirement is rather high compared to the thrust they produce, even next to terribly inefficient Korath engines."
 
 outfit "Ookii Rift Thruster"
@@ -290,14 +274,6 @@ outfit "Ookii Rift Thruster"
 		"rewind"
 		"scale" 0.8
 	"flare sound" "ion medium"
-	"reverse thrust" 3.7
-	"reverse thrusting energy" 0.44
-	"reverse thrusting heat" 0.25
-	"reverse flare sprite" "effect/bunrodea flare/large"
-		"frame rate" 1
-		"rewind"
-		"scale" 0.3
-	"reverse flare sound" "ion tiny"
 	description "Even though the energy drawn per unit thrust of rift engines is poorer than that of Korath engines, the overall energy requirement of rift engines is still far lesser by comparison."
 
 outfit "Subarashii Rift Thruster"
@@ -316,14 +292,6 @@ outfit "Subarashii Rift Thruster"
 		"frame rate" 1
 		"rewind"
 	"flare sound" "ion large"
-	"reverse thrust" 6.9
-	"reverse thrusting energy" 0.86
-	"reverse thrusting heat" 0.49
-	"reverse flare sprite" "effect/bunrodea flare/large"
-		"frame rate" 1
-		"rewind"
-		"scale" 0.4
-	"reverse flare sound" "ion tiny"
 	description "Given the lower size and thrust of rift engines, Bunrodean ships aren't well known for their pursuit capabilities. But there are rumors among some Bunrodea of an ancient cache of engines, more powerful than even those of the Korath, that would allow any ship to zip across the stars like a comet and chase down any potential target."
 
 outfit "Chiisana Rift Steering"

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -313,12 +313,6 @@ outfit "Small Thrust Module"
 	"flare sprite" "effect/coalition flare/small"
 		"frame rate" 10
 	"flare sound" "atomic tiny"
-	"reverse thrust" 1.1
-	"reverse thrusting energy" 0.046
-	"reverse thrusting heat" 0.3
-	"reverse flare sprite" "effect/coalition flare/small"
-		"frame rate" 10
-	"reverse flare sound" "atomic tiny"
 	description "This tiny thruster produces a considerable amount of thrust... but also a considerable amount of heat."
 	description "In order to optimize the production costs of propulsion systems for their vast transportation network, Coalition engineers opted to perfect a single thrust module that could be installed in varying configurations. As a result, up to four of these can be installed in a typical thruster slot."
 
@@ -339,12 +333,6 @@ outfit "Large Thrust Module"
 	"flare sprite" "effect/coalition flare/large"
 		"frame rate" 7
 	"flare sound" "atomic small"
-	"reverse thrust" 3.3
-	"reverse thrusting energy" 0.138
-	"reverse thrusting heat" 0.9
-	"reverse flare sprite" "effect/coalition flare/small"
-		"frame rate" 10
-	"reverse flare sound" "atomic tiny"
 	description "Coalition engineers prefer to focus on perfecting a few versatile designs rather than producing a wide range of them. As their large ships would require many of them stacked together to produce sufficient thrust, they created an array installation that incorporates three modules into a single mounting framework. Since two of these modules can be installed in a typical slot, it allows ships that require large amounts of thrust to incorporate six modules in a standard slot."
 	description "In order to facilitate the utilization of their modular designs, most ships of Coalition design have additional mounting brackets beyond the typical single standard slot."
 

--- a/data/gegno/gegno outfits.txt
+++ b/data/gegno/gegno outfits.txt
@@ -158,12 +158,6 @@ outfit "RG15 Torch Thruster"
 	"flare sprite" "effect/vi flare/small"
 		"frame rate" 2.5
 	"flare sound" "ion torch small"
-	"reverse thrust" 1.7
-	"reverse thrusting energy" 0.07
-	"reverse thrusting heat" 0.15
-	"reverse flare sprite" "effect/vi flare/small"
-		"frame rate" 2.5
-	"reverse flare sound" "ion torch small"
 	description `The RG15 Ion Torch Thruster is the Gegno Vi's smallest torch thruster, found almost exclusively on the Slate. It is somewhat inefficient, weighing more and producing more heat than most thrusters of a similar size in exchange for using slightly less energy.`
 
 
@@ -203,12 +197,6 @@ outfit "RG18 Torch Thruster"
 	"flare sprite" "effect/vi flare/medium"
 		"frame rate" 2.4
 	"flare sound" "ion torch medium"
-	"reverse thrust" 3.0
-	"reverse thrusting energy" 0.125
-	"reverse thrusting heat" 0.29
-	"reverse flare sprite" "effect/vi flare/small"
-		"frame rate" 2.5
-	"reverse flare sound" "ion torch small"
 	description `The RG18 is a moderately large thruster used by the Gegno Vi. Ion Torch Thrusters are similar to human ion thrusters, but their explosive exhaust causes them to run hotter. However, they also require slightly less energy.`
 
 
@@ -251,12 +239,6 @@ outfit "RG3 Torch Thruster"
 	"flare sprite" "effect/vi flare/large"
 		"frame rate" 2.3
 	"flare sound" "ion torch large"
-	"reverse thrust" 5.4
-	"reverse thrusting energy" 0.22
-	"reverse thrusting heat" 0.54
-	"reverse flare sprite" "effect/vi flare/small"
-		"frame rate" 2.5
-	"reverse flare sound" "ion torch small"
 	description `Derived from the massive thrusters that powered early Gegno generation ships, RG3 Ion Torch Thrusters are the Gegno's largest thrusters and the oldest still used. Smaller ships that attempt to use these engines often end up overheating themselves.`
 
 
@@ -316,12 +298,6 @@ outfit "SC-1 Plasma Engines"
 	"steering flare sprite" "effect/scin flare/tiny"
 		"frame rate" 0.6
 	"steering flare sound" "scplasma tiny"
-	"reverse thrust" 0.9
-	"reverse thrusting energy" 0.04
-	"reverse thrusting heat" 0.1
-	"reverse flare sprite" "effect/scin flare/tiny"
-		"frame rate" 0.6
-	"reverse flare sound" "scplasma tiny"
 	description `In order to power the tiny Halite frame, the Gegno Scin developed this smaller engine system. Based on their larger plasma thrusters, these engines are much more efficient than the Vi's bigger, more sluggish ion engines, which would never be compact or light enough to run on a fighter.`
 
 
@@ -343,12 +319,6 @@ outfit "SC-12 Plasma Thruster"
 	"flare sprite" "effect/scin flare/small"
 		"frame rate" 0.5
 	"flare sound" "scplasma small"
-	"reverse thrust" 2
-	"reverse thrusting energy" 0.085
-	"reverse thrusting heat" 0.225
-	"reverse flare sprite" "effect/scin flare/tiny"
-		"frame rate" 0.6
-	"reverse flare sound" "scplasma tiny"
 	description `Rather than developing on the Ion Torch design of the Vi, the Scin began work on a plasma-based thruster. They are more compact, weigh less, and produce significantly more thrust. However, since Ion Torches expel some of their heat in their thrust, the more stable and powerful SC thrusters tend to run hotter.`
 
 
@@ -390,12 +360,6 @@ outfit "SC-14 Plasma Thruster"
 	"flare sprite" "effect/scin flare/med"
 		"frame rate" 0.4
 	"flare sound" "scplasma medium"
-	"reverse thrust" 3.9
-	"reverse thrusting energy" 0.17
-	"reverse thrusting heat" 0.495
-	"reverse flare sprite" "effect/scin flare/tiny"
-		"frame rate" 0.6
-	"reverse flare sound" "scplasma tiny"
 	description `SC-14 class thrusters power the Scin's average gunboat or transport, giving their ships reliable speed. They can quickly propel any medium-sized ship forward with reasonable efficiency.`
 
 

--- a/data/hai/hai outfits.txt
+++ b/data/hai/hai outfits.txt
@@ -646,12 +646,6 @@ outfit `"Baellie" Atomic Engines`
 	"steering flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"steering flare sound" "atomic tiny"
-	"reverse thrust" 1.6
-	"reverse thrusting energy" 0.087
-	"reverse thrusting heat" 0.17
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description `While the Hai were designing the Flea, it quickly became apparent that even the "Basrem" engine set was too large for the purpose. As a result, a combined thruster steering set was created: "Baellie."`
 
 outfit `"Basrem" Atomic Thruster`
@@ -669,12 +663,6 @@ outfit `"Basrem" Atomic Thruster`
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
-	"reverse thrust" 2.3
-	"reverse thrusting energy" 0.14
-	"reverse thrusting heat" 0.28
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "Unbeknownst to the scientists of the Deep, the Hai have been using atomic engine technology for many millennia. Hai atomic engines are still much more energy hungry than other engines, but exhibit greater efficiency than their human counterparts."
 
 outfit `"Benga" Atomic Thruster`
@@ -692,12 +680,6 @@ outfit `"Benga" Atomic Thruster`
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
-	"reverse thrust" 3.7
-	"reverse thrusting energy" 0.25
-	"reverse thrusting heat" 0.48
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "Unlike human space where atomic engines are a rare sight to see and a luxury to have, many years of being confined to a relatively small pocket of the Galaxy has allowed all Hai ships to be outfitted with atomic engines."
 
 outfit `"Biroo" Atomic Thruster`
@@ -715,12 +697,6 @@ outfit `"Biroo" Atomic Thruster`
 	"flare sprite" "effect/atomic flare/small"
 		"frame rate" 13
 	"flare sound" "atomic small"
-	"reverse thrust" 6.2
-	"reverse thrusting energy" 0.4
-	"reverse thrusting heat" 0.82
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "This thruster is the standard thruster on most Hai light warships, providing enough thrust to make them usable in combat, but it is not quite big enough to suffice for something as large as a Hai Shield Beetle."
 
 outfit `"Bondir" Atomic Thruster`
@@ -738,12 +714,6 @@ outfit `"Bondir" Atomic Thruster`
 	"flare sprite" "effect/atomic flare/medium"
 		"frame rate" 12
 	"flare sound" "atomic medium"
-	"reverse thrust" 9.3
-	"reverse thrusting energy" 0.61
-	"reverse thrusting heat" 1.27
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "While Deep Sky was busy developing the combat atomic engines, the Hai were working on making theirs even better. Because of this, Hai atomic engines are highly efficient compared to their human variants, requiring less energy to fire and producing less heat in the process."
 
 outfit `"Bufaer" Atomic Thruster`
@@ -761,12 +731,6 @@ outfit `"Bufaer" Atomic Thruster`
 	"flare sprite" "effect/atomic flare/large"
 		"frame rate" 11
 	"flare sound" "atomic large"
-	"reverse thrust" 16.3
-	"reverse thrusting energy" 1.04
-	"reverse thrusting heat" 2.26
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "These thrusters are the largest of the Hai atomic thrusters, and one of the most powerful thrusters in known space. Beat out by only the largest human atomic thrusters, these massive engines provide enough thrust to push around even the largest of ships as if they were fighters."
 
 # Lateral thrusters. Using 90% for tiny, and 50% for huge, 10% steps in between.

--- a/data/human/engines.txt
+++ b/data/human/engines.txt
@@ -482,12 +482,6 @@ outfit "X1050 Ion Engines"
 	"steering flare sprite" "effect/ion flare/tiny"
 		"frame rate" 1.2
 	"steering flare sound" "ion tiny"
-	"reverse thrust" 1
-	"reverse thrusting energy" .04
-	"reverse thrusting heat" .06
-	"reverse flare sprite" "effect/ion flare/tiny"
-		"frame rate" 1.2
-	"reverse flare sound" "ion tiny"
 	description `When designing the Barb, the Syndicate took the opportunity to integrate their smallest thruster models to create a more compact steering and thrusting engine. The result is not very useful on anything but a fighter, and is only "adequate" in that role. Still, if engine space is at a premium, this is the smallest set of engines that will still get you there (eventually).`
 
 
@@ -509,12 +503,6 @@ outfit "X1700 Ion Thruster"
 	"flare sprite" "effect/ion flare/tiny"
 		"frame rate" 1.2
 	"flare sound" "ion tiny"
-	"reverse thrust" 1.4
-	"reverse thrusting energy" .06
-	"reverse thrusting heat" .09
-	"reverse flare sprite" "effect/ion flare/tiny"
-		"frame rate" 1.2
-	"reverse flare sound" "ion tiny"
 	description "This is the smallest thruster that you can buy, so weak that anything larger than a drone will accelerate quite slowly when using this engine. On the other hand, it is also very energy-efficient."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
@@ -535,12 +523,6 @@ outfit "X2700 Ion Thruster"
 	"flare sprite" "effect/ion flare/small"
 		"frame rate" 1.1
 	"flare sound" "ion small"
-	"reverse thrust" 2.4
-	"reverse thrusting energy" .11
-	"reverse thrusting heat" .17
-	"reverse flare sprite" "effect/ion flare/tiny"
-		"frame rate" 1.2
-	"reverse flare sound" "ion tiny"
 	description "The X2700 Ion Thruster is intended mostly for use in small, single-person or two-person ships, as well as in fighters. It is also used in larger ships, such as freighters, that have very little space for propulsion systems or energy to drive them. But these larger ships move unbearably slowly as a result."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
@@ -561,12 +543,6 @@ outfit "X3700 Ion Thruster"
 	"flare sprite" "effect/ion flare/medium"
 		"frame rate" 1.0
 	"flare sound" "ion medium"
-	"reverse thrust" 4.3
-	"reverse thrusting energy" .19
-	"reverse thrusting heat" .32
-	"reverse flare sprite" "effect/ion flare/tiny"
-		"frame rate" 1.2
-	"reverse flare sound" "ion tiny"
 	description "The X3700 Ion Thruster is designed for heavy freighters and small capital ships. In theory, it could be installed in smaller ships too, if they have enough engine space, to attain almost ridiculous speeds."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
@@ -587,12 +563,6 @@ outfit "X4700 Ion Thruster"
 	"flare sprite" "effect/ion flare/large"
 		"frame rate" 0.9
 	"flare sound" "ion large"
-	"reverse thrust" 8
-	"reverse thrusting energy" .35
-	"reverse thrusting heat" .62
-	"reverse flare sprite" "effect/ion flare/tiny"
-		"frame rate" 1.2
-	"reverse flare sound" "ion tiny"
 	description "The X4700 Ion Thruster was developed when the Republic Navy began building warships so large that the X3700 was not sufficient for them. It allows even a capital ship to move at a respectable speed."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
@@ -613,12 +583,6 @@ outfit "X5700 Ion Thruster"
 	"flare sprite" "effect/ion flare/huge"
 		"frame rate" 0.8
 	"flare sound" "ion huge"
-	"reverse thrust" 13.4
-	"reverse thrusting energy" .63
-	"reverse thrusting heat" 1.17
-	"reverse flare sprite" "effect/ion flare/tiny"
-		"frame rate" 1.2
-	"reverse flare sound" "ion tiny"
 	description "The X5700 thruster is intended for only the largest of capital ships. When the Syndicate first began producing them, these engines were considered little more than a publicity stunt, because no ship at the time was large enough to hold one."
 	description "	Ion engines consume less energy than plasma engines and produce less heat, but they also take up more space for the same amount of thrust."
 
@@ -859,12 +823,6 @@ outfit "Chipmunk Plasma Thruster"
 	"flare sprite" "effect/plasma flare/tiny"
 		"frame rate" 5
 	"flare sound" "plasma tiny"
-	"reverse thrust" 2.2
-	"reverse thrusting energy" 0.1
-	"reverse thrusting heat" 0.18
-	"reverse flare sprite" "effect/plasma flare/tiny"
-		"frame rate" 5
-	"reverse flare sound" "plasma tiny"
 	description "This is the smallest of the plasma propulsion systems produced by Delta V Corporation, suitable for very light fighters and interceptors."
 	description "	Plasma engines are a bit more powerful than ion engines of the same size, but they are less energy efficient and produce more heat."
 
@@ -885,12 +843,6 @@ outfit "Greyhound Plasma Thruster"
 	"flare sprite" "effect/plasma flare/small"
 		"frame rate" 6
 	"flare sound" "plasma small"
-	"reverse thrust" 3.8
-	"reverse thrusting energy" 0.18
-	"reverse thrusting heat" 0.34
-	"reverse flare sprite" "effect/plasma flare/tiny"
-		"frame rate" 5
-	"reverse flare sound" "plasma tiny"
 	description "This thruster is intended for small ships and for freighters. It comes in a crate decorated with a stylized cartoon of a running greyhound."
 	description "	Plasma engines are a bit more powerful than ion engines of the same size, but they are less energy efficient and produce more heat."
 
@@ -911,12 +863,6 @@ outfit "Impala Plasma Thruster"
 	"flare sprite" "effect/plasma flare/medium"
 		"frame rate" 7
 	"flare sound" "plasma medium"
-	"reverse thrust" 6.9
-	"reverse thrusting energy" 0.32
-	"reverse thrusting heat" 0.65
-	"reverse flare sprite" "effect/plasma flare/tiny"
-		"frame rate" 5
-	"reverse flare sound" "plasma tiny"
 	description "Impala class thrusters produce a significant amount of force, and are suitable for smaller capital ships. But, your ship may need extra cooling systems in order to handle them."
 	description "	Plasma engines are a bit more powerful than ion engines of the same size, but they are less energy efficient and produce more heat."
 
@@ -937,12 +883,6 @@ outfit "Orca Plasma Thruster"
 	"flare sprite" "effect/plasma flare/large"
 		"frame rate" 8
 	"flare sound" "plasma large"
-	"reverse thrust" 12.8
-	"reverse thrusting energy" 0.58
-	"reverse thrusting heat" 1.23
-	"reverse flare sprite" "effect/plasma flare/tiny"
-		"frame rate" 5
-	"reverse flare sound" "plasma tiny"
 	description "This engine draws enough power that a ship with anything short of a full-fledged nuclear reactor is unlikely to be able to use it, but the thrust it generates is impressive."
 	description "	Plasma engines are a bit more powerful than ion engines of the same size, but they are less energy efficient and produce more heat."
 
@@ -963,12 +903,6 @@ outfit "Tyrant Plasma Thruster"
 	"flare sprite" "effect/plasma flare/huge"
 		"frame rate" 9
 	"flare sound" "plasma huge"
-	"reverse thrust" 18.0
-	"reverse thrusting energy" 0.86
-	"reverse thrusting heat" 1.91
-	"reverse flare sprite" "effect/plasma flare/tiny"
-		"frame rate" 5
-	"reverse flare sound" "plasma tiny"
 	description "The enormous crate that this thruster is sold in comes decorated with a picture of a grinning Tyrannosaurus Rex with an improbable number of teeth. Only a handful of ships are large enough to require an engine of this size... or to have the capacity for one."
 	description "	Plasma engines are a bit more powerful than ion engines of the same size, but they are less energy efficient and produce more heat."
 
@@ -1212,12 +1146,6 @@ outfit "A120 Atomic Thruster"
 	"flare sprite" "effect/atomic flare/tiny"
 		"frame rate" 14
 	"flare sound" "atomic tiny"
-	"reverse thrust" 2.9
-	"reverse thrusting energy" 0.18
-	"reverse thrusting heat" 0.35
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "If you're looking for the most powerful engine that will fit into your ship, and have plenty of money to burn, Deep Sky's atomic thrusters are your answer. Of course, the extra energy and cooling they require can easily offset the benefit of their small size."
 
 outfit "A250 Atomic Thruster"
@@ -1237,12 +1165,6 @@ outfit "A250 Atomic Thruster"
 	"flare sprite" "effect/atomic flare/small"
 		"frame rate" 13
 	"flare sound" "atomic small"
-	"reverse thrust" 4.5
-	"reverse thrusting energy" 0.31
-	"reverse thrusting heat" 0.61
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "Deep Sky's atomic thrusters have been in production for centuries, but remain a niche product due to their high prices and high energy requirements."
 
 outfit "A370 Atomic Thruster"
@@ -1262,12 +1184,6 @@ outfit "A370 Atomic Thruster"
 	"flare sprite" "effect/atomic flare/medium"
 		"frame rate" 12
 	"flare sound" "atomic medium"
-	"reverse thrust" 7.5
-	"reverse thrusting energy" 0.51
-	"reverse thrusting heat" 1.03
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "This thruster is small enough to fit in a light warship or freighter, but powerful enough to move any but the largest of ships. Naturally, such performance comes at an exorbitant price."
 
 outfit "A520 Atomic Thruster"
@@ -1287,12 +1203,6 @@ outfit "A520 Atomic Thruster"
 	"flare sprite" "effect/atomic flare/large"
 		"frame rate" 11
 	"flare sound" "atomic large"
-	"reverse thrust" 12.2
-	"reverse thrusting energy" 0.83
-	"reverse thrusting heat" 1.74
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "If your ship is sporting a set of Deep Sky's atomic engines, you will be the envy of every pilot in the galaxy. No other form of propulsion that humanity has discovered produces so much thrust from such a small engine."
 
 outfit "A860 Atomic Thruster"
@@ -1312,12 +1222,6 @@ outfit "A860 Atomic Thruster"
 	"flare sprite" "effect/atomic flare/huge"
 		"frame rate" 10
 	"flare sound" "atomic huge"
-	"reverse thrust" 19.9
-	"reverse thrusting energy" 1.33
-	"reverse thrusting heat" 2.91
-	"reverse flare sprite" "effect/atomic flare/tiny"
-		"frame rate" 14
-	"reverse flare sound" "atomic tiny"
 	description "The A860 Atomic Thruster is the most powerful engine sold in human space, and is much more compact than any of the alternatives. But, you may need to upgrade your ship's power and cooling systems to handle it."
 
 

--- a/data/kahet/kahet outfits.txt
+++ b/data/kahet/kahet outfits.txt
@@ -425,11 +425,6 @@ outfit "Maeri Engine Nacelles"
 	"steering flare sprite" "effect/ka'het flare/large"
 		"frame rate" 30
 	"steering flare sound" "plasma medium"
-	"reverse thrust" 5.8
-	"reverse thrusting heat" 0.28
-	"reverse flare sprite" "effect/ka'het flare/medium"
-		"frame rate" 30
-	"reverse flare sound" "plasma small"
 	description "The Ka'het engines are peculiar in that they continuously draw large amounts of energy, but require no additional energy to activate: while this means that less power remains available for other subsystems, it is also somewhat more efficient than most types of propulsion, and generates only a tiny amount of heat."
 
 outfit "Ka'het Sustainer Nacelles"
@@ -461,11 +456,6 @@ outfit "Ka'het Sustainer Nacelles"
 	"steering flare sprite" "effect/ka'het flare/medium"
 		"frame rate" 30
 	"steering flare sound" "plasma small"
-	"reverse thrust" 2.5
-	"reverse thrusting heat" 0.1
-	"reverse flare sprite" "effect/ka'het flare/medium"
-		"frame rate" 30
-	"reverse flare sound" "plasma small"
 	description "While Ka'het vessels are already equipped with proper engines, most of them use a sustainer engine in addition to give the ship enough maneuverability to be useful in combat. Following the same design as its bigger cousins, the sustainer requires no power to function at the cost of constant energy consumption."
 
 outfit "Telis Engine Nacelles"
@@ -497,11 +487,6 @@ outfit "Telis Engine Nacelles"
 	"steering flare sprite" "effect/ka'het flare/large"
 		"frame rate" 30
 	"steering flare sound" "plasma medium"
-	"reverse thrust" 8.3
-	"reverse thrusting heat" 0.35
-	"reverse flare sprite" "effect/ka'het flare/medium"
-		"frame rate" 30
-	"reverse flare sound" "plasma small"
 	description "These nacelles used to comprise the entire engine block of a Telis'het. While their size is not impressive compared to other engines, if used in conjunction with a sustainer or two, they can be a powerful form of propulsion, combining both turning and thrusting engines in one."
 
 outfit "Vareti Engine Block"
@@ -530,11 +515,6 @@ outfit "Vareti Engine Block"
 	"steering flare sprite" "effect/ka'het flare/large"
 		"frame rate" 30
 	"steering flare sound" "plasma large"
-	"reverse thrust" 14.0
-	"reverse thrusting heat" 0.332
-	"reverse flare sprite" "effect/ka'het flare/medium"
-		"frame rate" 30
-	"reverse flare sound" "plasma small"
 	description "This is the largest single engine the Builders ever built, made for the most massive ships they were in control of. Due to its sheer size, it isn't as modular as its smaller equivalents, but it is more efficient and powerful as a result."
 
 outfit "Ka'het Compact Engine"
@@ -565,9 +545,4 @@ outfit "Ka'het Compact Engine"
 	"steering flare sprite" "effect/ka'het flare/medium"
 		"frame rate" 30
 	"steering flare sound" "plasma small"
-	"reverse thrust" 2.0
-	"reverse thrusting heat" 0.03
-	"reverse flare sprite" "effect/ka'het flare/medium"
-		"frame rate" 30
-	"reverse flare sound" "plasma small"
 	description "This tiny engine was developed as the main propulsion of the Ka'mar drones, long before the Ka'het were created and their nacelle design standardized. Improvements over time allowed it to maintain a comparable efficiency to the larger models, although unlike those, it requires some energy to activate the engines in addition to the constant energy drain that all Builder-designed engines have."

--- a/data/korath/korath outfits.txt
+++ b/data/korath/korath outfits.txt
@@ -399,12 +399,6 @@ outfit "Engine (Meteor Class)"
 	"steering flare sprite" "effect/korath flare/tiny"
 		"frame rate" 8
 	"steering flare sound" "plasma tiny"
-	"reverse thrust" 1.5
-	"reverse thrusting energy" 0.135
-	"reverse thrusting heat" 0.29
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "plasma tiny"
 	description `Although the prevailing Korath attitude towards engine construction has always been with a focus on making things bigger, faster, and more powerful, the Exiles found it necessary to develop these engines to allow their fighters to carry larger weapons or more cargo, at the cost of some speed.`
 
 
@@ -550,12 +544,6 @@ outfit "Thruster (Asteroid Class)"
 	"flare sprite" "effect/korath flare/tiny"
 		"frame rate" 8
 	"flare sound" "plasma tiny"
-	"reverse thrust" 2.1
-	"reverse thrusting energy" 0.15
-	"reverse thrusting heat" 0.34
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "plasma tiny"
 	description "Given its size, this tiny Korath thruster produces quite a kick. But, it also draws a considerable amount of power."
 
 
@@ -575,12 +563,6 @@ outfit "Thruster (Comet Class)"
 	"flare sprite" "effect/korath flare/small"
 		"frame rate" 7.5
 	"flare sound" "plasma small"
-	"reverse thrust" 3.7
-	"reverse thrusting energy" 0.28
-	"reverse thrusting heat" 0.65
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "plasma tiny"
 	description "Like most Korath technology, this thruster's power is offset by its energy requirements and heat output."
 
 
@@ -600,12 +582,6 @@ outfit "Thruster (Lunar Class)"
 	"flare sprite" "effect/korath flare/medium"
 		"frame rate" 7
 	"flare sound" "plasma medium"
-	"reverse thrust" 6.6
-	"reverse thrusting energy" 0.49
-	"reverse thrusting heat" 1.19
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "plasma tiny"
 	description "The Korath have the dubious distinction of relying on propulsion systems that produce more waste heat than the weapon systems of most other species."
 
 
@@ -625,12 +601,6 @@ outfit "Thruster (Planetary Class)"
 	"flare sprite" "effect/korath flare/large"
 		"frame rate" 6.5
 	"flare sound" "plasma large"
-	"reverse thrust" 12.0
-	"reverse thrusting energy" 0.89
-	"reverse thrusting heat" 2.27
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "plasma tiny"
 	description "The Quarg, who do all things efficiently, view the Korath propulsion systems with particular distaste."
 
 
@@ -650,12 +620,6 @@ outfit "Thruster (Stellar Class)"
 	"flare sprite" "effect/korath flare/huge"
 		"frame rate" 6
 	"flare sound" "plasma huge"
-	"reverse thrust" 14.9
-	"reverse thrusting energy" 1.58
-	"reverse thrusting heat" 4.26
-	"reverse flare sprite" "effect/korath flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "plasma tiny"
 	description "A legend among the Korath claims that when they were first testing out their latest generation of plasma thrusters, a concerned Quarg fleet approached and volunteered to help evacuate the Korath crew from what they assumed was a dying ship. The Quarg were surprised to learn that the flames shooting out the back of the ship were in fact its intended mode of propulsion."
 
 
@@ -857,12 +821,6 @@ outfit "Arkrof GP Hybrid Thruster"
 	"flare sprite" "effect/efreti flare/tiny"
 		"frame rate" 8
 	"flare sound" "ion tiny"
-	"reverse thrust" 2.8
-	"reverse thrusting energy" 0.26
-	"reverse thrusting heat" 0.3
-	"reverse flare sprite" "effect/efreti flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "ion tiny"
 	description "Efreti engineers have begun to grudgingly take inspiration from their not-entirely-welcome Quarg guardians. The incorporation of gravitational propulsion increases the thrust output for engines in this line, at the cost of even higher energy use. These are the smallest such gravitoplasma-based thrusters."
 
 
@@ -881,12 +839,6 @@ outfit "Farves GP Hybrid Thruster"
 	"flare sprite" "effect/efreti flare/small"
 		"frame rate" 7.5
 	"flare sound" "ion small"
-	"reverse thrust" 5.3
-	"reverse thrusting energy" 0.505
-	"reverse thrusting heat" 0.59
-	"reverse flare sprite" "effect/efreti flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "ion tiny"
 	description "The forced retreat from research into interstellar jump drive technology has left the Efreti engineers with little else to tinker with than subluminal propulsion. These resulting thrusters are one important example of this effort. Synthesizing gravitational propulsion with more traditional plasma thrusters moderates the heat output from these engines."
 
 
@@ -905,12 +857,6 @@ outfit "Gaktem GP Hybrid Thruster"
 	"flare sprite" "effect/efreti flare/medium"
 		"frame rate" 7
 	"flare sound" "ion medium"
-	"reverse thrust" 9.7
-	"reverse thrusting energy" 0.91
-	"reverse thrusting heat" 1.105
-	"reverse flare sprite" "effect/efreti flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "ion tiny"
 	description "The design of these engines suggests Efreti physicists appear to have gone considerably further than the mathematically self-consistent, but stubbornly unfalsifiable, conjectures of String Theory. Despite the Efreti's limited resources, these thrusters allow their engines to maintain the traditional Korath emphasis on speed in a small package while keeping heat output down."
 
 
@@ -929,12 +875,6 @@ outfit "Nelmeb GP Hybrid Thruster"
 	"flare sprite" "effect/efreti flare/large"
 		"frame rate" 6.5
 	"flare sound" "ion large"
-	"reverse thrust" 15.6
-	"reverse thrusting energy" 1.4
-	"reverse thrusting heat" 1.8
-	"reverse flare sprite" "effect/efreti flare/tiny"
-		"frame rate" 8
-	"reverse flare sound" "ion tiny"
 	description "Korath physicists have, for several centuries, understood concrete aspects of the unity that underlies both quantum gravity and the forces that bind quarks and gluons together. However, as Efreti efforts are comparatively recent, this technological synthesis lags behind comparable Quarg technology."
 	description "	These are the largest gravitoplasma thrusters that the Efreti have to offer, and as such are usually only found on their gargantuan civilian ships. Despite their size and thrusting power, the Quarg are still rather unimpressed with the inefficient nature of the design."
 

--- a/data/pug/pug outfits.txt
+++ b/data/pug/pug outfits.txt
@@ -255,12 +255,6 @@ outfit "Pug Akfar Thruster"
 	"flare sprite" "effect/pug flare/medium"
 		"frame rate" 20
 	"flare sound" "ion medium"
-	"reverse thrust" 4.8
-	"reverse thrusting energy" 0.22
-	"reverse thrusting heat" 0.31
-	"reverse flare sprite" "effect/pug flare/medium"
-		"frame rate" 20
-	"reverse flare sound" "ion tiny"
 	description "This is a small thruster designed by the Pug. It is not quite as powerful as a similarly sized atomic engine, but it makes up for that by being almost as energy efficient as ion engines."
 
 outfit "Pug Cormet Thruster"
@@ -278,12 +272,6 @@ outfit "Pug Cormet Thruster"
 	"flare sprite" "effect/pug flare/large"
 		"frame rate" 22
 	"flare sound" "ion large"
-	"reverse thrust" 7.1
-	"reverse thrusting energy" 0.33
-	"reverse thrusting heat" 0.46
-	"reverse flare sprite" "effect/pug flare/medium"
-		"frame rate" 20
-	"reverse flare sound" "ion tiny"
 	description "This is a medium-sized thruster designed by the Pug. It is not quite as powerful as a similarly sized atomic engine, but it makes up for that by being almost as energy efficient as ion engines."
 
 outfit "Pug Lohmar Thruster"
@@ -301,12 +289,6 @@ outfit "Pug Lohmar Thruster"
 	"flare sprite" "effect/pug flare/huge"
 		"frame rate" 23
 	"flare sound" "ion huge"
-	"reverse thrust" 10.3
-	"reverse thrusting energy" 0.49
-	"reverse thrusting heat" 0.69
-	"reverse flare sprite" "effect/pug flare/medium"
-		"frame rate" 20
-	"reverse flare sound" "ion tiny"
 	description "This is a large thruster designed by the Pug. It is not quite as powerful as a similarly sized atomic engine, but it makes up for that by being almost as energy efficient as ion engines."
 
 

--- a/data/quarg/quarg outfits.txt
+++ b/data/quarg/quarg outfits.txt
@@ -126,10 +126,6 @@ outfit "Medium Graviton Thruster"
 	"force protection" 0.15
 	"inertia reduction" 0.15
 	"flare sprite" "effect/medium graviton flare"
-	"reverse thrust" 12.0
-	"reverse thrusting energy" 2
-	"reverse thrusting heat" 0.2
-	"reverse flare sprite" "effect/medium graviton flare"
 	description "Quarg thrusters are quite powerful for their size and produce very little heat, but at the cost of consuming immense amounts of energy."
 	description "	They also have strange capabilities which seem to violate the laws of physics as humanity understands them. Ships with these engines accelerate faster under their own power than one would expect given the thrust of their engines, while also taking less impact from external forces."
 

--- a/data/sheragi/sheragi outfits.txt
+++ b/data/sheragi/sheragi outfits.txt
@@ -100,13 +100,6 @@ outfit "Fission Drive"
 		"frame rate" 30
 		"rewind"
 	"steering flare sound" "atomic tiny"
-	"reverse thrust" 2.7
-	"reverse thrusting energy" .15
-	"reverse thrusting heat" .286
-	"reverse flare sprite" "effect/fissionflare"
-		"frame rate" 30
-		"rewind"
-	"reverse flare sound" "atomic tiny"
 	description "A much smaller cousin of the Fusion Drive, it relies on fission instead of fusion to function, providing the necessary power generation and thrust to drive the Heavy Ion Cyclotron."
 
 outfit "Fusion Drive"

--- a/data/wanderer/wanderer outfits.txt
+++ b/data/wanderer/wanderer outfits.txt
@@ -439,12 +439,6 @@ outfit "Type 1 Radiant Thruster"
 	"flare sprite" "effect/wanderer flare/tiny"
 		"frame rate" 12
 	"flare sound" "plasma tiny"
-	"reverse thrust" 1.4
-	"reverse thrusting energy" .055
-	"reverse thrusting heat" .085
-	"reverse flare sprite" "effect/wanderer flare/tiny"
-		"frame rate" 12
-	"reverse flare sound" "plasma tiny"
 	description "This is the tiniest Wanderer engine. Like all their engines, it works in part by radiating excess heat, and as a result it doubles as a cooler for your ship."
 
 outfit "Type 2 Radiant Thruster"
@@ -465,12 +459,6 @@ outfit "Type 2 Radiant Thruster"
 	"flare sprite" "effect/wanderer flare/small"
 		"frame rate" 14
 	"flare sound" "plasma small"
-	"reverse thrust" 3.1
-	"reverse thrusting energy" .13
-	"reverse thrusting heat" .24
-	"reverse flare sprite" "effect/wanderer flare/tiny"
-		"frame rate" 12
-	"reverse flare sound" "plasma tiny"
 	description "Wanderer engines work by transferring excess heat from the ship into the exhaust plasma. When not providing thrust, the engines still serve as a cooling system."
 
 outfit "Type 3 Radiant Thruster"
@@ -491,12 +479,6 @@ outfit "Type 3 Radiant Thruster"
 	"flare sprite" "effect/wanderer flare/medium"
 		"frame rate" 16
 	"flare sound" "plasma medium"
-	"reverse thrust" 5.2
-	"reverse thrusting energy" .22
-	"reverse thrusting heat" .43
-	"reverse flare sprite" "effect/wanderer flare/tiny"
-		"frame rate" 12
-	"reverse flare sound" "plasma tiny"
 	description "Most engines this size generate a considerable amount of heat, but the Wanderers have developed a way of using the engine itself to vent extra heat from a ship, generating extra propulsive force in the process."
 
 outfit "Type 4 Radiant Thruster"
@@ -517,12 +499,6 @@ outfit "Type 4 Radiant Thruster"
 	"flare sprite" "effect/wanderer flare/large"
 		"frame rate" 18
 	"flare sound" "plasma large"
-	"reverse thrust" 8.7
-	"reverse thrusting energy" .37
-	"reverse thrusting heat" .76
-	"reverse flare sprite" "effect/wanderer flare/tiny"
-		"frame rate" 12
-	"reverse flare sound" "plasma tiny"
 	description "This is the largest engine that the Wanderers have developed. Its incredibly efficient design allows it to cool your ship even while it is firing."
 
 outfit "Type 1 Radiant Steering"

--- a/data/whispering void/critters.txt
+++ b/data/whispering void/critters.txt
@@ -36,7 +36,6 @@ ship "Pincer Beast"
 		"thrust" 37
 		"lateral thrust" 19
 		"turn" 1650
-		"reverse thrust" 2.5
 		"hull repair rate" 5
 		"energy capacity" 1000
 		"energy generation" 5


### PR DESCRIPTION
## Situation:

Back in #48 , reverse thrust was added to all thrusters to round out the complement of station keeping abilities. It makes logical sense as a capability spaceships should have in low amounts.

## Problems:

a) Player complaints about controls. It basically eliminated the ability to use the reverse course key. This has, I am told, been mostly resolved, although I forget how. 
b) Players don't want it. Or at least, they don't want it forced on them by having every drive automatically come with reverse thrust.
c) The AI doesn't really seem to handle it that well.
d) The presence of reverse thrust can be handwaved for not-clearly-understood thruster types, but it doesn't make a lot of sense for the human fairly well understood ones like ion, plasma, and atomic where they are fairly clearly understood. Particularly since normal reverse thrusters take up forward weapon space, too.

## Result:

We already have reverse thruster options in the game. Both as stand-alone options, and a few dual forward+reverse thrust options as well. There isn't a need to force everyone to get reverse thrust as part of having a thruster. So, this PR is removing the reverse thrust from all those outfits that didn't normally have it.

If it is determined that more ships should have reverse thrust, then they should get reverse thrusters installed. Perhaps there need to be more reverse thrusters, too. 

This also follows the pattern of lateral thrusters. Those were originally automatic and forced on every ship all the time; which has now been removed and replaced by having actual lateral thruster outfits, which people can do away with if they want. It will make navigation more challenging, but people are free to make that sacrifice if they choose to.