### PR TITLE
Feat(data): Nerfing stock ship configurations

### DIFF
--- a/data/bunrodea/bunrodea ships.txt
+++ b/data/bunrodea/bunrodea ships.txt
@@ -42,8 +42,6 @@ ship "Kaiken"
 		
 		"Solar Battery"
 		"Solar Cell" 27
-		"Small Shield Relay"
-		"Shield Relay Limiter" 6
 		
 		"Chiisana Rift Thruster" # Extra thruster
 		"Chiisana Rift LTC"
@@ -97,16 +95,13 @@ ship "Sasumata"
 			"hit force" 1350
 	outfits
 		"Swarm Pod" 2
-		"Swarm Missile" 1000
-		"Swarm Clip"
+		"Swarm Missile" 400
 		"Buzzer Anti-Missile" 2
 		
 		"Quark Reactor"
 		"Reactor Overclocker" 2
 		"Solar Battery" 2
 		"Solar Cell" 30
-		"Large Shield Relay"
-		"Shield Relay Limiter" 10
 		
 		"Subarashii Rift Thruster"
 		"Subarashii Rift LTC"
@@ -167,7 +162,6 @@ ship "Tanto"
 		
 		"Solar Battery" 2
 		"Solar Cell" 42
-		"Small Shield Relay"
 		
 		"Ookii Rift Thruster"
 		"Ookii Rift LTC"
@@ -299,8 +293,6 @@ ship "Tekkan"
 		"Quark Reactor"
 		"Solar Battery"
 		"Solar Cell" 36
-		"Small Shield Relay"
-		"Shield Relay Booster" 5
 		
 		"Ookii Rift Thruster"
 		"Ookii Rift LTC"
@@ -359,9 +351,6 @@ ship "Kunai"
 		"Quark Reactor"
 		"Solar Battery" 2
 		"Solar Cell" 28
-		"Small Shield Relay"
-		"Shield Relay Booster" 4
-		"Small Nanite Fabricator"
 		
 		"Ookii Rift Thruster"
 		"Ookii Rift LTC"
@@ -418,15 +407,12 @@ ship "Kama"
 	outfits
 		"Mandible Cannon" 4
 		"Swarm Pod" 6
-		"Swarm Missile" 2400
+		"Swarm Missile" 1200
 		
 		"Electroweak Reactor"
 		"Reactor Overclocker" 2
 		"Solar Battery"
 		"Solar Cell" 36
-		"Large Shield Relay"
-		"Shield Relay Booster" 6
-		"Outfits Expansion" 2
 		
 		"Ookii Rift Thruster"
 		"Ookii Rift LTC"
@@ -497,15 +483,13 @@ ship "Chigiriki"
 		"Thorax Cannon"
 		"Locust Blaster" 6
 		"Swarm Pod" 10
-		"Swarm Missile" 4000
+		"Swarm Missile" 2000
 		
 		"Dark Reactor"
 		"Reactor Limiter" 3
 		"Solar Battery" 3
 		"Solar Cell" 19
-		"Large Shield Relay"
-		"Shield Relay Booster" 16
-		"Outfits Expansion" 4
+		"Outfits Expansion" 2
 		
 		"Ookii Rift Thruster"
 		"Ookii Rift LTC"

--- a/data/coalition/coalition outfits.txt
+++ b/data/coalition/coalition outfits.txt
@@ -120,7 +120,7 @@ outfit "Small Shield Module"
 	"shield generation" .28
 	"shield energy" .28
 	"shield heat" .1
-	description "Although combat is almost unheard of in Coalition space, almost all of their ships are able to recharge their shields when necessary."
+	description "Although combat is almost unheard of in Coalition space, many captains find it useful to be able to have their ships recharge their shields when necessary."
 
 outfit "Large Shield Module"
 	category "Systems"

--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -44,7 +44,6 @@ ship "Arach Courier"
 	outfits
 		"Small Collector Module"
 		"Small Battery Module"
-		"Small Repair Module"
 		
 		"Small Thrust Module" 2
 		"Small Lateral Thrust Module" 2
@@ -112,8 +111,6 @@ ship "Arach Freighter"
 	outfits
 		"Small Collector Module" 3
 		"Small Battery Module" 2
-		"Small Shield Module"
-		"Small Repair Module" 2
 		
 		"Large Thrust Module"
 		"Large Lateral Thrust Module"
@@ -194,8 +191,6 @@ ship "Arach Hulk"
 		"Large Collector Module"
 		"Large Battery Module"
 		"Small Battery Module"
-		"Small Shield Module" 2
-		"Large Repair Module"
 		
 		"Large Thrust Module" 2
 		"Large Lateral Thrust Module" 2
@@ -281,8 +276,6 @@ ship "Arach Spindle"
 		"Large Collector Module"
 		"Large Battery Module"
 		"Small Battery Module"
-		"Small Shield Module" 2
-		"Small Repair Module" 3
 		"Cooling Module"
 		
 		"Large Thrust Module" 2
@@ -407,8 +400,6 @@ ship "Arach Transport"
 	outfits
 		"Small Collector Module" 2
 		"Small Battery Module"
-		"Small Shield Module"
-		"Small Repair Module"
 		
 		"Large Thrust Module"
 		"Large Lateral Thrust Module"
@@ -485,12 +476,10 @@ ship "Heliarch Breacher"
 		"Bombardment Cannon" 2
 		"Bombardment Turret"
 		"Finisher Pod"
-		"Finisher Torpedo" 40
+		"Finisher Torpedo" 20
 		
 		"Small Reactor Module" 2
 		"Small Battery Module"
-		"Overcharged Shield Module"
-		"Overclocked Repair Module"
 		"Cooling Module" 2
 		"Scanning Module"
 		"Enforcer Riot Staff" 8
@@ -544,7 +533,7 @@ ship "Heliarch Breacher" "Heliarch Breacher (Missile)"
 	outfits
 		"Finisher Pod" 3
 		"Finisher Storage Tube" 2
-		"Finisher Torpedo" 160
+		"Finisher Torpedo" 80
 		
 		"Small Reactor Module"
 		"Small Battery Module"
@@ -618,14 +607,12 @@ ship "Heliarch Hunter"
 			"hit force" 3000
 	outfits
 		"Finisher Pod" 3
-		"Finisher Torpedo" 120
+		"Finisher Torpedo" 60
 		"Bombardment Turret"
 		"Heliarch Attractor"
 		
 		"Large Reactor Module"
 		"Small Battery Module" 3
-		"Overcharged Shield Module"
-		"Overclocked Repair Module"
 		"Cooling Module" 2
 		"Scanning Module" 2
 		"Enforcer Riot Staff" 25
@@ -663,7 +650,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Burst Fire)"
 	outfits
 		"Finisher Maegrolain" 2
 		"Finisher Storage Tube" 2
-		"Finisher Torpedo" 160
+		"Finisher Torpedo" 80
 		
 		"Large Reactor Module"
 		"Small Battery Module" 2
@@ -695,7 +682,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Interdicting)"
 	outfits
 		"Finisher Pod" 2
 		"Finisher Storage Tube"
-		"Finisher Torpedo" 100
+		"Finisher Torpedo" 50
 		"Heliarch Attractor"
 		"Heliarch Repulsor"
 		
@@ -756,7 +743,7 @@ ship "Heliarch Hunter" "Heliarch Hunter (Missile)"
 	outfits
 		"Finisher Pod" 3
 		"Finisher Storage Tube" 6
-		"Finisher Torpedo" 240
+		"Finisher Torpedo" 120
 		
 		"Large Reactor Module"
 		"Small Battery Module" 2
@@ -835,15 +822,12 @@ ship "Heliarch Interdictor"
 			"hit force" 3800
 	outfits
 		"Finisher Pod" 2
-		"Finisher Storage Tube"
-		"Finisher Torpedo" 100
+		"Finisher Torpedo" 40
 		"Heliarch Attractor"
 		"Heliarch Repulsor"
 		
 		"Large Reactor Module"
 		"Small Battery Module" 4
-		"Overcharged Shield Module"
-		"Overclocked Repair Module"
 		"Cooling Module" 2
 		"Scanning Module" 3
 		"Enforcer Riot Staff" 28
@@ -877,7 +861,7 @@ ship "Heliarch Interdictor" "Heliarch Interdictor (Bombardment)"
 	outfits
 		"Finisher Pod" 2
 		"Finisher Storage Tube" 2
-		"Finisher Torpedo" 120
+		"Finisher Torpedo" 60
 		"Bombardment Turret" 2
 		
 		"Large Reactor Module"
@@ -902,7 +886,7 @@ ship "Heliarch Interdictor" "Heliarch Interdictor (Burst Fire)"
 	outfits
 		"Finisher Maegrolain" 2
 		"Finisher Storage Tube" 4
-		"Finisher Torpedo" 200
+		"Finisher Torpedo" 100
 		
 		"Large Reactor Module"
 		"Small Battery Module" 4
@@ -950,7 +934,7 @@ ship "Heliarch Interdictor" "Heliarch Interdictor (Missile)"
 	outfits
 		"Finisher Pod" 2
 		"Finisher Storage Tube" 13
-		"Finisher Torpedo" 340
+		"Finisher Torpedo" 170
 
 		"Small Reactor Module" 2
 		"Overcharged Shield Module"
@@ -1029,8 +1013,7 @@ ship "Heliarch Judicator"
 			"hit force" 3800
 	outfits
 		"Finisher Pod" 2
-		"Finisher Torpedo" 140
-		"Finisher Storage Tube" 3
+		"Finisher Torpedo" 40
 		"Ion Hail Turret"
 		
 		"Large Reactor Module"
@@ -1131,7 +1114,7 @@ ship "Heliarch Judicator" "Heliarch Judicator (Missile)"
 	outfits
 		"Finisher Pod" 2
 		"Finisher Storage Tube" 14
-		"Finisher Torpedo" 360
+		"Finisher Torpedo" 180
 		
 		"Small Reactor Module" 2
 		"Small Battery Module"
@@ -1155,7 +1138,7 @@ ship "Heliarch Judicator" "Heliarch Judicator (Repulsor)"
 	outfits
 		"Finisher Pod" 2
 		"Finisher Storage Tube" 3
-		"Finisher Torpedo" 140
+		"Finisher Torpedo" 70
 		"Heliarch Repulsor"
 		
 		"Large Reactor Module"
@@ -1239,8 +1222,6 @@ ship "Heliarch Neutralizer"
 		
 		"Small Reactor Module" 2
 		"Small Battery Module" 3
-		"Overcharged Shield Module"
-		"Overclocked Repair Module"
 		"Cooling Module" 2
 		"Scanning Module" 2
 		"Enforcer Riot Staff" 9
@@ -1276,7 +1257,7 @@ ship "Heliarch Neutralizer" "Heliarch Neutralizer (Missile)"
 	outfits
 		"Finisher Pod" 2
 		"Finisher Storage Tube" 4
-		"Finisher Torpedo" 160
+		"Finisher Torpedo" 80
 
 		"Small Reactor Module"
 		"Overcharged Shield Module"
@@ -1382,13 +1363,11 @@ ship "Heliarch Punisher"
 	outfits
 		"Ion Rain Gun" 4
 		"Finisher Pod" 2
-		"Finisher Torpedo" 80
+		"Finisher Torpedo" 40
 		"Bombardment Turret" 4
 		
 		"Large Reactor Module" 2
 		"Large Battery Module"
-		"Overcharged Shield Module" 2
-		"Overclocked Repair Module" 2
 		"Cooling Module" 4
 		"Scanning Module" 4
 		"Enforcer Riot Staff" 78
@@ -1433,7 +1412,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Burst Fire)"
 	outfits
 		"Finisher Maegrolain" 4
 		"Finisher Storage Tube" 4
-		"Finisher Torpedo" 320
+		"Finisher Torpedo" 160
 		
 		"Large Reactor Module"
 		"Small Reactor Module"
@@ -1464,7 +1443,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Burst Fire)"
 ship "Heliarch Punisher" "Heliarch Punisher (Fuel)"
 	outfits
 		"Finisher Pod" 2
-		"Finisher Torpedo" 80
+		"Finisher Torpedo" 40
 		"Bombardment Turret" 4
 		
 		"Large Reactor Module" 2
@@ -1490,7 +1469,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Interdicting)"
 	outfits
 		"Bombardment Cannon" 4
 		"Finisher Pod" 2
-		"Finisher Torpedo" 80
+		"Finisher Torpedo" 40
 		"Heliarch Attractor" 2
 		"Heliarch Repulsor"
 		"Bombardment Turret"
@@ -1556,7 +1535,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Ions)"
 ship "Heliarch Punisher" "Heliarch Punisher (Missile)"
 	outfits
 		"Finisher Pod" 6
-		"Finisher Torpedo" 240
+		"Finisher Torpedo" 120
 		"Heliarch Repulsor"
 		
 		"Large Reactor Module" 2
@@ -1585,7 +1564,7 @@ ship "Heliarch Punisher" "Heliarch Punisher (Pure Finishers)"
 	outfits
 		"Finisher Pod" 6
 		"Finisher Storage Tube" 21
-		"Finisher Torpedo" 660
+		"Finisher Torpedo" 330
 
 		"Large Reactor Module"
 		"Overcharged Shield Module"
@@ -1662,8 +1641,6 @@ ship "Heliarch Pursuer"
 		"Large Collector Module"
 		"Small Collector Module" 2
 		"Small Battery Module"
-		"Small Shield Module"
-		"Small Repair Module"
 		
 		"Small Steering Module" 2
 		"Small Thrust Module" 2
@@ -1731,8 +1708,6 @@ ship "Heliarch Rover"
 		"Large Collector Module"
 		"Small Battery Module" 2
 		"Small Cogeneration Module"
-		"Small Shield Module"
-		"Small Repair Module" 3
 		
 		"Small Thrust Module" 2
 		"Small Lateral Thrust Module" 2
@@ -1865,7 +1840,6 @@ ship "Kimek Briar"
 	outfits
 		"Small Collector Module" 2
 		"Small Battery Module" 2
-		"Small Shield Module" 2
 		
 		"Large Thrust Module"
 		"Large Lateral Thrust Module"
@@ -1935,8 +1909,6 @@ ship "Kimek Spire"
 		"Large Collector Module"
 		"Small Collector Module"
 		"Large Battery Module"
-		"Large Shield Module"
-		"Small Shield Module"
 		
 		"Large Thrust Module" 2
 		"Large Lateral Thrust Module" 2
@@ -2014,7 +1986,6 @@ ship "Kimek Thistle"
 	outfits
 		"Large Collector Module"
 		"Small Battery Module"
-		"Small Shield Module" 3
 		
 		"Large Thrust Module"
 		"Large Lateral Thrust Module"
@@ -2116,7 +2087,6 @@ ship "Kimek Thorn"
 	outfits
 		"Small Collector Module"
 		"Small Battery Module"
-		"Small Shield Module"
 		
 		"Small Thrust Module" 2
 		"Small Lateral Thrust Module" 2
@@ -2142,7 +2112,6 @@ ship "Kimek Thorn" "Kimek Thorn (Miner)"
 		"Small Cogeneration Module" 2
 		"Small Collector Module"
 		"Small Battery Module"
-		"Small Shield Module"
 		
 		"Small Thrust Module" 2
 		"Small Lateral Thrust Module" 2
@@ -2183,7 +2152,6 @@ ship "Saryd Runabout"
 	outfits
 		"Small Collector Module" 2
 		"Small Battery Module"
-		"Small Shield Module"
 		
 		"Small Thrust Module" 2
 		"Small Lateral Thrust Module" 2
@@ -2358,8 +2326,6 @@ ship "Saryd Traveler"
 	outfits
 		"Small Collector Module" 3
 		"Small Battery Module" 2
-		"Small Shield Module" 2
-		"Small Repair Module"
 		
 		"Large Thrust Module"
 		"Large Lateral Thrust Module"
@@ -2442,8 +2408,6 @@ ship "Saryd Visitor"
 	outfits
 		"Small Collector Module" 2
 		"Small Battery Module" 2
-		"Small Shield Module"
-		"Small Repair Module"
 		
 		"Small Thrust Module" 3
 		"Small Lateral Thrust Module" 3

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -47,7 +47,6 @@ ship "Anomalocaris"
 		"Boulder Reactor"
 		"Pebble Core"
 		"Hai Ravine Batteries"
-		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 3
 		"Quantum Keystone"
 		"Pulse Rifle" 20
@@ -132,7 +131,6 @@ ship "Aphid"
 		"Chameleon Anti-Missile"
 		"Sand Cell" 2
 		"Hai Fissure Batteries"
-		"Hai Corundum Regenerator"
 		`"Basrem" Atomic Thruster`
 		`"Basrem" Atomic LTC`
 		`"Basrem" Atomic Steering`
@@ -224,10 +222,9 @@ ship "Centipede"
 			"hit force" 900
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 56
 		"Bullfrog Anti-Missile" 3
 		"Geode Reactor"
-		"Hai Corundum Regenerator"
 		"Hai Ravine Batteries"
 		"Hai Williwaw Cooling" 3
 		"Hai Cuttlefish Jammer" 2
@@ -262,7 +259,7 @@ ship "Centipede"
 ship "Centipede" "Centipede (Holovid)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 56
 		"Bullfrog Anti-Missile" 3
 		"Geode Reactor"
 		"Hai Corundum Regenerator"
@@ -310,7 +307,7 @@ ship "Centipede" "Centipede (Durable)"
 		`"Biroo" Atomic Steering`
 		"Hai Gorge Batteries"
 		"Hai Williwaw Cooling" 3
-		"Hai Tracker" 168
+		"Hai Tracker" 84
 		`"Biroo" Atomic Thruster`
 		`"Biroo" Atomic LTC`
 		"Boulder Reactor"
@@ -331,7 +328,7 @@ ship "Centipede" "Centipede (Refugees)"
 		`"Biroo" Atomic Steering`
 		"Hai Gorge Batteries"
 		"Hai Williwaw Cooling" 3
-		"Hai Tracker" 168
+		"Hai Tracker" 84
 		`"Biroo" Atomic Thruster`
 		`"Biroo" Atomic LTC`
 		"Boulder Reactor"
@@ -369,13 +366,11 @@ ship "Cicada"
 			"hit force" 1280
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 84
-		"Tracker Storage Pod"
+		"Hai Tracker" 28
 		"Bullfrog Anti-Missile" 2
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
 		"Hai Gorge Batteries"
-		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling"
 		"Quantum Keystone"
 		`"Benga" Atomic Thruster`
@@ -488,7 +483,6 @@ ship "Geocoris"
 		"Hai Cuttlefish Jammer" 4
 		"Geode Reactor" 2
 		"Hai Valley Batteries"
-		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 4
 		`"Biroo" Reverse Thruster`
 		`"Biroo" Atomic Thruster`
@@ -522,7 +516,7 @@ ship "Geocoris"
 ship "Geocoris" "Geocoris (Tracker)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 196
+		"Hai Tracker" 98
 		"Pulse Turret" 2
 		"Bullfrog Anti-Missile" 2
 		"Chameleon Anti-Missile"
@@ -578,7 +572,6 @@ ship "Grasshopper"
 		"Pulse Cannon" 2
 		"Sand Cell" 2
 		"Hai Fissure Batteries"
-		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Quantum Keystone"
 		"Pulse Rifle"
@@ -603,7 +596,7 @@ ship "Grasshopper"
 ship "Grasshopper" "Grasshopper (Tracker)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 56
 		"Pebble Core"
 		"Hai Fissure Batteries"
 		"Hai Corundum Regenerator"
@@ -683,7 +676,6 @@ ship "Lightning Bug"
 		"Hai Cuttlefish Jammer"
 		"Geode Reactor"
 		"Hai Gorge Batteries"
-		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Quantum Keystone"
 		"Pulse Rifle" 2
@@ -729,7 +721,7 @@ ship "Lightning Bug" "Lightning Bug (Phantom Pallet)"
 ship "Lightning Bug" "Lightning Bug (Pulse)"
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Hai Tracker" 28
 		"Pulse Turret" 2
 		"Geode Reactor"
 		"Hai Gorge Batteries"
@@ -744,7 +736,7 @@ ship "Lightning Bug" "Lightning Bug (Pulse)"
 ship "Lightning Bug" "Lightning Bug (Surveillance)"
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Hai Tracker" 28
 		"Pulse Turret"
 		"Bullfrog Anti-Missile"
 		"Geode Reactor"
@@ -820,11 +812,10 @@ ship "Ladybug"
 	outfits
 		"Ion Cannon" 2
 		"Hai Tracker Pod" 1
-		"Hai Tracker" 56
+		"Hai Tracker" 28
 		"Chameleon Anti-Missile"
 		"Pulse Turret"
 
-		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 2
 		"Hai Fissure Batteries"
 		"Hai Chasm Batteries"
@@ -917,7 +908,7 @@ ship "Ladybug" "Ladybug (Tracker)"
 	outfits
 		"Hai Tracker Pod" 3
 		"Tracker Storage Pod" 5
-		"Hai Tracker" 308
+		"Hai Tracker" 154
 		"Pulse Turret"
 		"Chameleon Anti-Missile"
 
@@ -1029,7 +1020,7 @@ ship "Pond Strider"
 ship "Pond Strider" "Pond Strider (Tracker)"
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 112
+		"Hai Tracker" 56
 		"Railgun" 2
 		"Railgun Slug" 2000
 		"Tracker Storage Pod" 2
@@ -1140,9 +1131,8 @@ ship "Sea Scorpion"
 		"Chameleon Anti-Missile"
 		"Fuel Pod"
 		"Geode Reactor"
-		"Hai Diamond Regenerator"
 		"Hai Ravine Batteries"
-		"Hai Tracker" 336
+		"Hai Tracker" 168
 		"Hai Tracker Pod" 4
 		"Hai Williwaw Cooling"
 		"Pulse Rifle" 15
@@ -1196,7 +1186,7 @@ ship "Sea Scorpion" "Sea Scorpion (Tracker)"
 		"Hai Tracker Pod" 4
 		"Chameleon Anti-Missile" 2
 		"Tracker Storage Pod" 4
-		"Hai Tracker" 336
+		"Hai Tracker" 168
 		"Hai Williwaw Cooling" 2
 		"Hai Octopus Jammer"
 		"Boulder Reactor"
@@ -1231,7 +1221,7 @@ ship "Sea Scorpion" "Sea Scorpion (Ion)"
 		"Ion Cannon" 3
 		"Hai Tracker Pod"
 		"Tracker Storage Pod"
-		"Hai Tracker" 84
+		"Hai Tracker" 42
 		"Boulder Reactor"
 		"Hai Fissure Batteries"
 		"Hai Diamond Regenerator" 2
@@ -1332,7 +1322,6 @@ ship "Scarab"
 		"Chameleon Anti-Missile"
 		"Pebble Core"
 		"Hai Fissure Batteries"
-		"Hai Corundum Regenerator"
 		"Hai Williwaw Cooling"
 		"Quantum Keystone"
 		"Pulse Rifle"
@@ -1386,14 +1375,12 @@ ship "Shield Beetle"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 280
-		"Tracker Storage Pod" 2
+		"Hai Tracker" 112
 		"Bullfrog Anti-Missile" 4
 		"Hai Cuttlefish Jammer" 3
 		"Boulder Reactor"
 		"Geode Reactor"
 		"Hai Valley Batteries"
-		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling" 3
 		"Quantum Keystone"
 		"Pulse Rifle" 55
@@ -1447,7 +1434,7 @@ ship "Shield Beetle" "Shield Beetle (Police)"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Hai Tracker" 112
 		"Chameleon Anti-Missile" 2
 		"Boulder Reactor" 2
 		"Hai Chasm Batteries" 2
@@ -1490,7 +1477,7 @@ ship "Shield Beetle" "Shield Beetle (Unfettered)"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 252
+		"Hai Tracker" 126
 		"Tracker Storage Pod"
 		"Bullfrog Anti-Missile" 4
 		"Hai Octopus Jammer" 3
@@ -1511,7 +1498,7 @@ ship "Shield Beetle" "Shield Beetle (Unfettered)"
 ship "Shield Beetle" "Shield Beetle (Unfettered Shipyards)"
 	outfits
 		"Ion Cannon" 2
-		"Hai Tracker" 420
+		"Hai Tracker" 210
 		"Hai Tracker Pod" 6
 		"Tracker Storage Pod" 3
 		"Pulse Turret" 3
@@ -1538,7 +1525,7 @@ ship "Shield Beetle" "Shield Beetle (Pulse Tracker)"
 	outfits
 		"Hai Tracker Pod" 8
 		"Tracker Storage Pod" 7
-		"Hai Tracker" 644
+		"Hai Tracker" 322
 		"Chameleon Anti-Missile" 2
 		"Pulse Turret" 2
 		
@@ -1579,7 +1566,7 @@ ship "Shield Beetle" "Shield Beetle (Jump)"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 224
+		"Hai Tracker" 112
 		"Chameleon Anti-Missile" 2
 		"Boulder Reactor" 2
 		"Hai Chasm Batteries" 2
@@ -1659,7 +1646,7 @@ ship "Shield Beetle" "Shield Beetle (Fuel Jump)"
 	outfits
 		"Ion Cannon" 4
 		"Hai Tracker Pod" 4
-		"Hai Tracker" 280
+		"Hai Tracker" 140
 		"Jump Drive"
 		"Quantum Keystone"
 		"Outfits Expansion" 4
@@ -1739,7 +1726,7 @@ ship "Shield Beetle" "Shield Beetle (Plasma Blaster Jump)"
 ship "Shield Beetle" "Shield Beetle (Jump, Tracker)"
 	outfits
 		"Hai Tracker Pod" 8
-		"Hai Tracker" 448
+		"Hai Tracker" 224
 		"Pulse Turret" 4
 		"Boulder Reactor" 2
 		"Hai Ravine Batteries"
@@ -1820,7 +1807,7 @@ ship "Shield Beetle" "Shield Beetle (Durable Pulse)"
 ship "Shield Beetle" "Shield Beetle (Tracker)"
 	outfits
 		"Hai Tracker Pod" 8
-		"Hai Tracker" 560
+		"Hai Tracker" 280
 		"Tracker Storage Pod" 4
 		"Pulse Turret" 4
 		"Boulder Reactor"
@@ -1843,7 +1830,7 @@ ship "Shield Beetle" "Shield Beetle (Tripulse Ionic Turret)"
 		"Pulse Cannon" 2
 		"Pulse Turret"
 		"Tripulse Shredder" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 56
 		"Hai Tracker Pod" 2
 		"Chameleon Anti-Missile" 2
 		"Bullfrog Anti-Missile"
@@ -2017,7 +2004,7 @@ ship "Solifuge"
 			"hit force" 3500
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Hai Tracker" 28
 		"Ion Cannon" 4
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile"
@@ -2084,7 +2071,7 @@ ship "Solifuge"
 ship "Solifuge" "Solifuge (Jump)"
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Hai Tracker" 28
 		"Ion Cannon" 4
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile"
@@ -2140,7 +2127,7 @@ ship "Solifuge" "Solifuge (Jump, Pulse)"
 ship "Solifuge" "Solifuge (Jump, Tracker)"
 	outfits
 		"Hai Tracker Pod" 5
-		"Hai Tracker" 280
+		"Hai Tracker" 140
 		"Pulse Turret" 4
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 2
@@ -2196,7 +2183,7 @@ ship "Solifuge" "Solifuge (Pulse)"
 ship "Solifuge" "Solifuge (Tracker)"
 	outfits
 		"Hai Tracker Pod" 5
-		"Hai Tracker" 280
+		"Hai Tracker" 140
 		"Pulse Turret" 4
 		"Chameleon Anti-Missile"
 		"Bullfrog Anti-Missile" 2
@@ -2242,7 +2229,7 @@ ship "Violin Spider"
 			"hit force" 180
 	outfits
 		"Hai Tracker Pod"
-		"Hai Tracker" 56
+		"Hai Tracker" 28
 		"Pebble Core"
 		Supercapacitor
 		"Hai Williwaw Cooling"
@@ -2310,13 +2297,11 @@ ship "Water Bug"
 			"hit force" 1860
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 168
-		"Tracker Storage Pod" 2
+		"Hai Tracker" 56
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
 		"Hai Gorge Batteries"
-		"Hai Diamond Regenerator"
 		"Hai Williwaw Cooling"
 		"Quantum Keystone"
 		`"Basrem" Reverse Thruster`
@@ -2345,7 +2330,7 @@ ship "Water Bug"
 ship "Water Bug" "Water Bug (Phantom Pallet)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 168
+		"Hai Tracker" 84
 		"Tracker Storage Pod" 2
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
@@ -2365,7 +2350,7 @@ ship "Water Bug" "Water Bug (Phantom Pallet)"
 ship "Water Bug" "Water Bug (Jump)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 56
 		"Pulse Turret"
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -2384,7 +2369,7 @@ ship "Water Bug" "Water Bug (Jump)"
 ship "Water Bug" "Water Bug (Pulse)"
 	outfits
 		"Hai Tracker Pod" 2
-		"Hai Tracker" 112
+		"Hai Tracker" 56
 		"Pulse Turret" 3
 		"Geode Reactor"
 		"Hai Gorge Batteries"

--- a/data/human/marauders.txt
+++ b/data/human/marauders.txt
@@ -45,7 +45,6 @@ ship "Marauder Arrow"
 		
 		"Dwarf Core"
 		"LP072a Battery Pack"
-		"D14-RN Shield Generator"
 		"Cooling Ducts"
 		"Laser Rifle" 5
 		
@@ -158,7 +157,6 @@ ship "Marauder Bounder"
 
 		"Dwarf Core"
 		"LP072a Battery Pack"
-		"Hai Corundum Regenerator"
 		"Outfits Expansion"
 		"Water Coolant System"
 		"Security Station"
@@ -285,7 +283,6 @@ ship "Marauder Falcon"
 		"Fusion Reactor"
 		"Dwarf Core"
 		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 3
@@ -446,7 +443,6 @@ ship "Marauder Firebird"
 		
 		"Fusion Reactor"
 		"Supercapacitor"
-		"D41-HY Shield Generator"
 		"Liquid Helium Cooler"
 		"Outfits Expansion"
 		"Laser Rifle" 25
@@ -592,8 +588,6 @@ ship "Marauder Leviathan"
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
-		"D67-TM Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Outfits Expansion" 2
@@ -641,7 +635,7 @@ ship "Marauder Leviathan" "Marauder Leviathan (Engines)"
 		"Heavy Rocket Launcher" 4
 		"Heavy Rocket" 80
 		"Gatling Turret" 4
-		"Gatling Gun Ammo" 24000
+		"Gatling Gun Ammo" 12000
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
@@ -738,12 +732,11 @@ ship "Marauder Manta"
 	outfits
 		"Plasma Cannon" 4
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Quad Blaster Turret"
 		
 		"Dwarf Core"
 		"LP144a Battery Pack"
-		"D14-RN Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Security Station" 3
 		"Laser Rifle" 8
@@ -784,7 +777,7 @@ ship "Marauder Manta" "Marauder Manta (Engines)"
 	outfits
 		"Plasma Cannon" 4
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Quad Blaster Turret"
 		
 		"Dwarf Core"
@@ -822,7 +815,7 @@ ship "Marauder Manta" "Marauder Manta (Weapons)"
 		"Particle Cannon" 2
 		"Proton Gun" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Heavy Anti-Missile Turret"
 		
 		"Fission Reactor"
@@ -888,7 +881,6 @@ ship "Marauder Quicksilver"
 		
 		"NT-200 Nucleovoltaic"
 		"Hai Fissure Batteries"
-		"D41-HY Shield Generator"
 		"Water Coolant System"
 		"Security Station" 3
 		"Laser Rifle"
@@ -1069,7 +1061,6 @@ ship "Marauder Raven"
 		
 		"Breeder Reactor"
 		"Supercapacitor" 3
-		"Hai Corundum Regenerator"
 		"Liquid Nitrogen Cooler"
 		"Outfits Expansion"
 		
@@ -1201,7 +1192,6 @@ ship "Marauder Splinter"
 		
 		"Fusion Reactor"
 		"LP036a Battery Pack"
-		"D67-TM Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 22
 		"Nerve Gas" 2

--- a/data/human/outfits.txt
+++ b/data/human/outfits.txt
@@ -57,7 +57,7 @@ outfit "D14-RN Shield Generator"
 	"outfit space" -15
 	"shield generation" .2
 	"shield energy" .2
-	description "This is the standard shield generator for fighters and interceptors, as well as for many non-combat starships. Although it is possible for a ship to have no shield generator at all, recharging its shield matrix only when landed in a hospitable spaceport, life in deep space is unpredictable enough that most pilots find shield generators to be well worth the space they take up."
+	description "This is the shield generator most commonly used as an upgrade for fighters and interceptors, as well as for many non-combat starships. Although most ships are sold with no shield generator at all, recharging its shield matrix only when landed in a hospitable spaceport, life in deep space is unpredictable enough that many pilots find shield generators to be well worth the space they take up."
 
 outfit "D23-QP Shield Generator"
 	category "Systems"
@@ -67,7 +67,7 @@ outfit "D23-QP Shield Generator"
 	"outfit space" -22
 	"shield generation" .32
 	"shield energy" .32
-	description "This is a slightly more powerful shield generator than the standard model installed in most small ships. If combat lasts long enough, the increased recharge rate is enough to give you an edge, but recharging your shields completely will still take a long time."
+	description "This is a slightly more powerful shield generator than the model installed in many small ships. If combat lasts long enough, the increased recharge rate is enough to give you an edge, but recharging your shields completely will still take a long time."
 
 outfit "D41-HY Shield Generator"
 	category "Systems"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -40,7 +40,7 @@ ship "Aerie"
 			"hit force" 1200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		
@@ -118,7 +118,7 @@ ship "Argosy"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Blaster Turret"
 		"Anti-Missile Turret"
 		
@@ -189,7 +189,7 @@ ship "Arrow"
 			"hit force" 360
 	outfits
 		"Sidewinder Missile Pod" 2
-		"Sidewinder Missile" 12
+		"Sidewinder Missile" 6
 		"Anti-Missile Turret"
 		
 		"Dwarf Core"
@@ -253,7 +253,7 @@ ship "Auxiliary"
 			"hit force" 4200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -330,9 +330,9 @@ ship "Bactrian"
 			"hit force" 3900
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Torpedo Launcher"
-		"Torpedo" 30
+		"Torpedo" 16
 		"Heavy Laser Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		
@@ -467,7 +467,7 @@ ship "Bastion"
 	outfits
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 60
+		"Heavy Rocket" 31
 		"Heavy Rocket Rack" 2
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
@@ -605,7 +605,7 @@ ship "Berserker"
 	outfits
 		"Energy Blaster" 2
 		"Javelin Mini Pod" 2
-		"Javelin" 60
+		"Javelin" 31
 		
 		"nGVF-CC Fuel Cell"
 		"LP072a Battery Pack"
@@ -816,7 +816,7 @@ ship "Bulk Freighter"
 			"hit force" 1800
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 23
 		"Laser Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -885,7 +885,7 @@ ship "Bulwark"
 	outfits
 		"Plasma Cannon" 2
 		"Heavy Rocket Launcher" 2
-		"Heavy Rocket" 60
+		"Heavy Rocket" 31
 		"Heavy Rocket Rack" 2
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret"
@@ -957,11 +957,11 @@ ship "Carrier"
 			"hit force" 4500
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Sidewinder Missile Rack" 8
-		"Sidewinder Missile" 184
+		"Sidewinder Missile" 97
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 31
 		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1068,7 +1068,7 @@ ship "Class C Freighter"
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 23
 		
 		"Fusion Reactor"
 		"LP036a Battery Pack"
@@ -1163,7 +1163,7 @@ ship "Clipper"
 	outfits
 		"Beam Laser" 2
 		"Javelin Mini Pod" 2
-		"Javelin" 60
+		"Javelin" 31
 		
 		"nGVF-DD Fuel Cell"
 		"LP072a Battery Pack"
@@ -1272,7 +1272,7 @@ ship "Container Transport"
 			"hit force" 1800
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 23
 		"Laser Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1338,7 +1338,7 @@ ship "Corvette"
 	outfits
 		"Heavy Laser" 2
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Heavy Laser Turret"
 		"Anti-Missile Turret"
 		
@@ -1413,7 +1413,7 @@ ship "Cruiser"
 	outfits
 		"Particle Cannon" 4
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1506,7 +1506,7 @@ ship "Cutthroat"
 		"Twin Modified Blaster" 2
 		"Torpedo Pod" 2
 		"Torpedo Storage Rack"
-		"Torpedo" 21
+		"Torpedo" 11
 		
 		"Fission Reactor"
 		"LP036a Battery Pack"
@@ -1568,7 +1568,7 @@ ship "Dagger"
 	outfits
 		"Beam Laser"
 		"Javelin Mini Pod" 2
-		"Javelin" 60
+		"Javelin" 31
 		
 		"nGVF-AA Fuel Cell"
 		"Supercapacitor"
@@ -1626,7 +1626,7 @@ ship "Dreadnought"
 			"hit force" 3900
 	outfits
 		"Torpedo Launcher" 4
-		"Torpedo" 120
+		"Torpedo" 61
 		"Plasma Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1814,7 +1814,7 @@ ship "Falcon"
 	outfits
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 31
 		"Quad Blaster Turret" 3
 		"Heavy Anti-Missile Turret"
 		
@@ -1889,7 +1889,7 @@ ship "Finch"
 		"Beam Laser"
 		"Javelin Mini Pod" 2
 		"Javelin Storage Crate"
-		"Javelin" 160
+		"Javelin" 81
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
@@ -1944,9 +1944,9 @@ ship "Firebird"
 	outfits
 		"Twin Blaster" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 31
 		"Quad Blaster Turret"
 		"Anti-Missile Turret"
 		
@@ -2128,7 +2128,7 @@ ship "Frigate"
 	outfits
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 31
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
 		
@@ -2329,7 +2329,7 @@ ship "Hauler"
 			"hit force" 900
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Meteor Missile" 7
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2394,7 +2394,7 @@ ship "Hauler II"
 			"hit force" 1200
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 59
+		"Meteor Missile" 15
 		"Meteor Missile Box" 3
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -2461,7 +2461,7 @@ ship "Hauler III"
 			"hit force" 1500
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 59
+		"Meteor Missile" 15
 		"Meteor Missile Box" 3
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
@@ -2855,7 +2855,7 @@ ship "Lance"
 	outfits
 		"Energy Blaster"
 		"Sidewinder Missile Pod" 2
-		"Sidewinder Missile" 12
+		"Sidewinder Missile" 6
 		
 		"nGVF-AA Fuel Cell"
 		"Supercapacitor" 4
@@ -2912,9 +2912,9 @@ ship "Leviathan"
 		"Quad Blaster Turret" 3
 		"Anti-Missile Turret"
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 31
 		
 		"Breeder Reactor"
 		"KP-6 Photovoltaic Panel" 2
@@ -2992,7 +2992,7 @@ ship "Mammoth"
 			"hit force" 2100
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Proton Turret" 2
 		"Quad Blaster Turret" 2
 		"Anti-Missile Turret" 4
@@ -3074,7 +3074,7 @@ ship "Manta"
 	outfits
 		"Particle Cannon" 4
 		"Torpedo Storage Rack"
-		"Torpedo" 21
+		"Torpedo" 11
 		"Torpedo Pod" 2
 		
 		"RT-I Radiothermal"
@@ -3178,7 +3178,7 @@ ship "Modified Argosy"
 	outfits
 		"Heavy Laser" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret"
 		
@@ -3250,7 +3250,7 @@ ship "Mule"
 			"hit force" 1500
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 136
+		"Sidewinder Missile" 68
 		"Sidewinder Missile Rack" 2
 		"Heavy Laser Turret" 2
 		"Anti-Missile Turret" 2
@@ -3323,7 +3323,7 @@ ship "Nest"
 			"hit force" 900
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -3524,7 +3524,7 @@ ship "Protector"
 			"hit force" 2400
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Quad Blaster Turret" 6
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
@@ -3648,7 +3648,7 @@ ship "Rainmaker"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 180
+		"Meteor Missile" 91
 		"Meteor Missile Box" 4
 		
 		"nGVF-CC Fuel Cell"
@@ -3710,9 +3710,9 @@ ship "Raven"
 	outfits
 		"Heavy Laser" 2
 		"Torpedo Launcher"
-		"Torpedo" 30
+		"Torpedo" 16
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 23
 		
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Panel" 2
@@ -3773,7 +3773,7 @@ ship "Roost"
 			"hit force" 1200
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 31
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -3847,7 +3847,7 @@ ship "Saber"
 	outfits
 		"Beam Laser" 3
 		"Javelin Pod" 2
-		"Javelin" 600
+		"Javelin" 310
 		"Javelin Storage Crate" 2
 		"Blaster Turret"
 		
@@ -4071,7 +4071,7 @@ ship "Skein"
 			"hit force" 1500
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 29
+		"Meteor Missile" 15
 		"Meteor Missile Box"
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret"
@@ -4322,7 +4322,7 @@ ship "Star Queen"
 			"hit force" 900
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 23
 		"Heavy Anti-Missile Turret" 2
 		
 		"KP-6 Photovoltaic Array" 4
@@ -4496,7 +4496,7 @@ ship "Valkyrie"
 		"Quad Blaster Turret" 2
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 31
 		
 		"NT-200 Nucleovoltaic"
 		"KP-6 Photovoltaic Panel" 3
@@ -4643,7 +4643,7 @@ ship "Wasp"
 	outfits
 		"Energy Blaster" 2
 		"Sidewinder Missile Pod"
-		"Sidewinder Missile" 6
+		"Sidewinder Missile" 3
 		
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -118,7 +118,7 @@ ship "Argosy"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Blaster Turret"
 		"Anti-Missile Turret"
 		
@@ -332,7 +332,7 @@ ship "Bactrian"
 		"Sidewinder Missile Launcher" 2
 		"Sidewinder Missile" 45
 		"Torpedo Launcher"
-		"Torpedo" 16
+		"Torpedo" 15
 		"Heavy Laser Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		
@@ -957,11 +957,11 @@ ship "Carrier"
 			"hit force" 4500
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Sidewinder Missile Rack" 8
-		"Sidewinder Missile" 97
+		"Sidewinder Missile" 92
 		"Torpedo Launcher" 2
-		"Torpedo" 31
+		"Torpedo" 30
 		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1505,8 +1505,7 @@ ship "Cutthroat"
 	outfits
 		"Twin Modified Blaster" 2
 		"Torpedo Pod" 2
-		"Torpedo Storage Rack"
-		"Torpedo" 11
+		"Torpedo" 4
 		
 		"Fission Reactor"
 		"LP036a Battery Pack"
@@ -1626,7 +1625,7 @@ ship "Dreadnought"
 			"hit force" 3900
 	outfits
 		"Torpedo Launcher" 4
-		"Torpedo" 61
+		"Torpedo" 60
 		"Plasma Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		
@@ -1814,7 +1813,7 @@ ship "Falcon"
 	outfits
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 31
+		"Torpedo" 30
 		"Quad Blaster Turret" 3
 		"Heavy Anti-Missile Turret"
 		
@@ -1944,9 +1943,9 @@ ship "Firebird"
 	outfits
 		"Twin Blaster" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Torpedo Launcher" 2
-		"Torpedo" 31
+		"Torpedo" 30
 		"Quad Blaster Turret"
 		"Anti-Missile Turret"
 		
@@ -2128,7 +2127,7 @@ ship "Frigate"
 	outfits
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 31
+		"Torpedo" 30
 		"Blaster Turret" 2
 		"Anti-Missile Turret"
 		
@@ -2329,7 +2328,7 @@ ship "Hauler"
 			"hit force" 900
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 7
+		"Meteor Missile" 6
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2394,8 +2393,8 @@ ship "Hauler II"
 			"hit force" 1200
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 15
-		"Meteor Missile Box" 3
+		"Meteor Missile" 22
+		"Meteor Missile Box" 2
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2461,8 +2460,8 @@ ship "Hauler III"
 			"hit force" 1500
 	outfits
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 15
-		"Meteor Missile Box" 3
+		"Meteor Missile" 22
+		"Meteor Missile Box" 2
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -2912,9 +2911,9 @@ ship "Leviathan"
 		"Quad Blaster Turret" 3
 		"Anti-Missile Turret"
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Torpedo Launcher" 2
-		"Torpedo" 31
+		"Torpedo" 30
 		
 		"Breeder Reactor"
 		"KP-6 Photovoltaic Panel" 2
@@ -3073,8 +3072,7 @@ ship "Manta"
 			"hit force" 1200
 	outfits
 		"Particle Cannon" 4
-		"Torpedo Storage Rack"
-		"Torpedo" 11
+		"Torpedo" 3
 		"Torpedo Pod" 2
 		
 		"RT-I Radiothermal"
@@ -3178,7 +3176,7 @@ ship "Modified Argosy"
 	outfits
 		"Heavy Laser" 2
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Heavy Laser Turret"
 		"Heavy Anti-Missile Turret"
 		
@@ -3250,8 +3248,7 @@ ship "Mule"
 			"hit force" 1500
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 68
-		"Sidewinder Missile Rack" 2
+		"Sidewinder Missile" 45
 		"Heavy Laser Turret" 2
 		"Anti-Missile Turret" 2
 		
@@ -3323,7 +3320,7 @@ ship "Nest"
 			"hit force" 900
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -3524,7 +3521,7 @@ ship "Protector"
 			"hit force" 2400
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Quad Blaster Turret" 6
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
@@ -3648,7 +3645,7 @@ ship "Rainmaker"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 91
+		"Meteor Missile" 90
 		"Meteor Missile Box" 4
 		
 		"nGVF-CC Fuel Cell"
@@ -3710,7 +3707,7 @@ ship "Raven"
 	outfits
 		"Heavy Laser" 2
 		"Torpedo Launcher"
-		"Torpedo" 16
+		"Torpedo" 15
 		"Sidewinder Missile Launcher"
 		"Sidewinder Missile" 23
 		
@@ -3773,7 +3770,7 @@ ship "Roost"
 			"hit force" 1200
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 31
+		"Meteor Missile" 30
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -4496,7 +4493,7 @@ ship "Valkyrie"
 		"Quad Blaster Turret" 2
 		"Particle Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 31
+		"Torpedo" 30
 		
 		"NT-200 Nucleovoltaic"
 		"KP-6 Photovoltaic Panel" 3

--- a/data/human/ships.txt
+++ b/data/human/ships.txt
@@ -47,7 +47,7 @@ ship "Aerie"
 		"NT-200 Nucleovoltaic"
 		"KP-6 Photovoltaic Panel" 2
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Large Radar Jammer"
 		"Laser Rifle" 3
 		
@@ -124,7 +124,7 @@ ship "Argosy"
 		
 		"RT-I Radiothermal"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		
 		"RC27 Reaction Thruster"
 		"RC24 Reaction LTC"
@@ -194,7 +194,6 @@ ship "Arrow"
 		
 		"Dwarf Core"
 		"Supercapacitor"
-		"D14-RN Shield Generator"
 		"Small Radar Jammer"
 		"Luxury Accommodations"
 		
@@ -261,7 +260,6 @@ ship "Auxiliary"
 		"Fusion Reactor"
 		"LP288a Battery Pack"
 		"D94-YV Shield Generator"
-		"D67-TM Shield Generator"
 		"Water Coolant System"
 		"Large Radar Jammer"
 		"Ramscoop"
@@ -340,7 +338,7 @@ ship "Bactrian"
 		
 		"Fusion Reactor"
 		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
 		"Large Radar Jammer"
 		"Ramscoop"
 		"Laser Rifle" 15
@@ -477,7 +475,7 @@ ship "Bastion"
 		"S3 Thermionic"
 		"LP144a Battery Pack"
 		"nGVF-BB Fuel Cell"
-		"D67-TM Shield Generator"
+		"D41-HY Shield Generator"
 		"Water Coolant System"
 		"Tactical Scanner"
 		"Laser Rifle" 7
@@ -543,7 +541,6 @@ ship "Behemoth"
 		
 		"NT-200 Nucleovoltaic"
 		"LP144a Battery Pack"
-		"D41-HY Shield Generator"
 		"Small Radar Jammer"
 		"Laser Rifle" 3
 		
@@ -612,7 +609,7 @@ ship "Berserker"
 		
 		"nGVF-CC Fuel Cell"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		
 		"RC27 Reaction Thruster"
 		"RC24 Reaction LTC"
@@ -672,7 +669,6 @@ ship "Blackbird"
 		"S3 Thermionic"
 		"KP-6 Photovoltaic Array" 3
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
 		"Small Radar Jammer"
 		"Luxury Accommodations"
 		
@@ -729,7 +725,6 @@ ship "Bounder"
 		"nGVF-CC Fuel Cell"
 		"KP-6 Photovoltaic Array"
 		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
 		
 		"RC37 Reaction Thruster"
 		"RC34 Reaction LTC"
@@ -827,7 +822,6 @@ ship "Bulk Freighter"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
-		"D23-QP Shield Generator"
 		"Laser Rifle"
 		
 		"RC37 Reaction Thruster"
@@ -898,7 +892,7 @@ ship "Bulwark"
 		
 		"Fission Reactor"
 		"LP144a Battery Pack"
-		"D94-YV Shield Generator"
+		"D67-TM Shield Generator"
 		"Water Coolant System"
 		"Tactical Scanner"
 		"Laser Rifle" 19
@@ -1173,7 +1167,6 @@ ship "Clipper"
 		
 		"nGVF-DD Fuel Cell"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
 		
 		"RC27 Reaction Thruster"
 		"RC24 Reaction LTC"
@@ -1285,7 +1278,6 @@ ship "Container Transport"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
-		"D23-QP Shield Generator"
 		"Laser Rifle"
 		
 		"RC37 Reaction Thruster"
@@ -1427,7 +1419,7 @@ ship "Cruiser"
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
-		"D67-TM Shield Generator"
+		"D41-HY Shield Generator"
 		"Large Radar Jammer" 2
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 20
@@ -1504,7 +1496,7 @@ ship "Cutthroat"
 		"lateral thruster slot" 1
 		"reverse thruster slot" 1
 		"steering slot" 1
-		"thruster slot" 1
+		"thruster slot" 2
 		weapon
 			"blast radius" 36
 			"shield damage" 360
@@ -1519,7 +1511,6 @@ ship "Cutthroat"
 		"Fission Reactor"
 		"LP036a Battery Pack"
 		"Water Coolant System"
-		"D23-QP Shield Generator"
 		"Laser Rifle" 5
 		
 		"RC37 Reaction Thruster"
@@ -1642,7 +1633,7 @@ ship "Dreadnought"
 		"Breeder Reactor"
 		"S3 Thermionic"
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Small Radar Jammer"
 		"Liquid Helium Cooler"
 		"Tactical Scanner"
@@ -1831,7 +1822,7 @@ ship "Falcon"
 		"KP-6 Photovoltaic Array"
 		"KP-6 Photovoltaic Panel" 2
 		"LP144a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 15
@@ -1962,7 +1953,7 @@ ship "Firebird"
 		"RT-I Radiothermal"
 		"nGVF-AA Fuel Cell"
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Laser Rifle" 3
 		
 		"RC37 Reaction Thruster"
@@ -2029,7 +2020,6 @@ ship "Flivver"
 		"nGVF-BB Fuel Cell"
 		"KP-6 Photovoltaic Panel" 3
 		"Supercapacitor"
-		"D14-RN Shield Generator"
 		
 		"RC17 Reaction Thruster"
 		"RC14 Reaction LTC"
@@ -2083,7 +2073,6 @@ ship "Freighter"
 		
 		"nGVF-DD Fuel Cell"
 		"LP072a Battery Pack"
-		"D14-RN Shield Generator"
 		
 		"RC27 Reaction Thruster"
 		"RC24 Reaction LTC"
@@ -2146,7 +2135,7 @@ ship "Frigate"
 		"NT-200 Nucleovoltaic"
 		"LP072a Battery Pack"
 		"LP036a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Large Radar Jammer"
 		"Laser Rifle" 5
 		"Fragmentation Grenades" 5
@@ -2346,7 +2335,6 @@ ship "Hauler"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
 		"Small Radar Jammer"
 		
 		"RC27 Reaction Thruster"
@@ -2413,7 +2401,6 @@ ship "Hauler II"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
 		"Small Radar Jammer"
 		"Laser Rifle"
 		
@@ -2481,7 +2468,6 @@ ship "Hauler III"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
 		"Small Radar Jammer"
 		"Laser Rifle"
 		
@@ -2547,7 +2533,7 @@ ship "Hawk"
 		"nGVF-CC Fuel Cell"
 		"KP-6 Photovoltaic Panel" 2
 		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		"Small Radar Jammer"
 		
 		"RC27 Reaction Thruster"
@@ -2603,7 +2589,7 @@ ship "Headhunter"
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Array"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		
 		"RC27 Reaction Thruster"
 		"RC24 Reaction LTC"
@@ -2665,7 +2651,6 @@ ship "Heavy Shuttle"
 	outfits
 		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
 		
 		"RC27 Reaction Thruster"
 		"RC24 Reaction LTC"
@@ -2718,7 +2703,6 @@ ship "Hogshead"
 		"KP-6 Photovoltaic Array" 2
 		"LP036a Battery Pack"
 
-		"D41-HY Shield Generator"
 		"Small Radar Jammer" 2
 		"Luxury Accommodations"
 		
@@ -2775,7 +2759,6 @@ ship "Lampyrid Mk. II"
 		"Anti-Missile Turret"
 		"KP-6 Photovoltaic Array"
 		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
 		"Small Radar Jammer"
 		"Ramscoop"
 	
@@ -2936,7 +2919,7 @@ ship "Leviathan"
 		"Breeder Reactor"
 		"KP-6 Photovoltaic Panel" 2
 		"LP144a Battery Pack"
-		"D67-TM Shield Generator"
+		"D41-HY Shield Generator"
 		"Liquid Helium Cooler"
 		"Laser Rifle" 15
 		
@@ -3016,7 +2999,7 @@ ship "Mammoth"
 		
 		"Fission Reactor"
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Large Radar Jammer"
 		"Cooling Ducts"
 		"Catalytic Ramscoop"
@@ -3201,7 +3184,7 @@ ship "Modified Argosy"
 		
 		"NT-200 Nucleovoltaic"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		"Small Radar Jammer"
 		"Brig"
 		"Laser Rifle" 12
@@ -3275,7 +3258,7 @@ ship "Mule"
 		"NT-200 Nucleovoltaic"
 		"KP-6 Photovoltaic Array"
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Small Radar Jammer" 2
 		"Ramscoop"
 		"Laser Rifle"
@@ -3346,7 +3329,7 @@ ship "Nest"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator" 2
+		"D23-QP Shield Generator" 2
 		"Large Radar Jammer"
 		"Laser Rifle" 2
 		
@@ -3413,7 +3396,7 @@ ship "Nighthawk"
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Array" 3
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		"Large Radar Jammer"
 		"Tactical Scanner"
 		"Laser Rifle" 24
@@ -3476,7 +3459,7 @@ ship "Osprey"
 		
 		"Breeder Reactor"
 		"LP036a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Large Radar Jammer"
 		"Liquid Helium Cooler"
 		"Laser Rifle" 3
@@ -3548,7 +3531,7 @@ ship "Protector"
 		
 		"Fusion Reactor"
 		"LP288a Battery Pack"
-		"D67-TM Shield Generator"
+		"D41-HY Shield Generator"
 		"Small Radar Jammer" 3
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 6
@@ -3670,7 +3653,6 @@ ship "Rainmaker"
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
 		"Large Radar Jammer"
 		"Tactical Scanner"
 		
@@ -3735,7 +3717,7 @@ ship "Raven"
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Panel" 2
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator"
+		"D23-QP Shield Generator"
 		"Laser Rifle" 2
 		
 		"RC37 Reaction Thruster"
@@ -3797,7 +3779,7 @@ ship "Roost"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
-		"D41-HY Shield Generator" 4
+		"D23-QP Shield Generator" 4
 		"Large Radar Jammer"
 		"Tactical Scanner"
 		"Laser Rifle" 2
@@ -3871,7 +3853,7 @@ ship "Saber"
 		
 		"nGVF-CC Fuel Cell"
 		"LP072a Battery Pack"
-		"D23-QP Shield Generator"
+		"D14-RN Shield Generator"
 		
 		"RC37 Reaction Thruster"
 		"RC34 Reaction LTC"
@@ -3934,7 +3916,6 @@ ship "Scout"
 		
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
 		"Small Radar Jammer"
 		"Ramscoop"
 		
@@ -4042,7 +4023,6 @@ ship "Shuttle"
 	outfits
 		"nGVF-AA Fuel Cell"
 		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
 		
 		"RC27 Reaction Thruster"
 		"RC24 Reaction LTC"
@@ -4099,7 +4079,7 @@ ship "Skein"
 		
 		"S3 Thermionic"
 		"LP072a Battery Pack"
-		"D67-TM Shield Generator" 4
+		"D41-HY Shield Generator" 4
 		"Tactical Scanner"
 		"Laser Rifle" 4
 		
@@ -4233,7 +4213,7 @@ ship "Splinter"
 		
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
-		"D67-TM Shield Generator"
+		"D41-HY Shield Generator"
 		"Small Radar Jammer" 2
 		"Water Coolant System"
 		"Laser Rifle"
@@ -4296,7 +4276,6 @@ ship "Star Barge"
 
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
-		"D14-RN Shield Generator"
 		
 		"RC17 Reaction Thruster"
 		"RC14 Reaction LTC"
@@ -4348,7 +4327,6 @@ ship "Star Queen"
 		
 		"KP-6 Photovoltaic Array" 4
 		"LP036a Battery Pack"
-		"D94-YV Shield Generator"
 		"Small Radar Jammer" 3
 		"Luxury Accommodations"
 		
@@ -4416,7 +4394,6 @@ ship "Sunder"
 		"Asteroid Scanner"
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
-		"D23-QP Shield Generator"
 
 		"RC37 Reaction Thruster"
 		"RC34 Reaction LTC"
@@ -4524,7 +4501,7 @@ ship "Valkyrie"
 		"NT-200 Nucleovoltaic"
 		"KP-6 Photovoltaic Panel" 3
 		"LP072a Battery Pack"
-		"D67-TM Shield Generator"
+		"D41-HY Shield Generator"
 		"Large Radar Jammer"
 		"Laser Rifle" 18
 		"Nerve Gas" 3
@@ -4591,7 +4568,7 @@ ship "Vanguard"
 
 		"Fusion Reactor"
 		"LP072a Battery Pack"
-		"D67-TM Shield Generator"
+		"D41-HY Shield Generator"
 		"Liquid Nitrogen Cooler"
 		"Laser Rifle" 4
 		

--- a/data/human/variants.txt
+++ b/data/human/variants.txt
@@ -75,7 +75,7 @@ ship "Argosy" "Argosy (Laser)"
 ship "Argosy" "Argosy (Missile)"
 	outfits
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 165
+		"Meteor Missile" 82
 		"Meteor Missile Box" 3
 		"Anti-Missile Turret" 2
 		"Fission Reactor"
@@ -108,7 +108,7 @@ ship "Argosy" "Argosy (Raider)"
 	outfits
 		"Energy Blaster" 4
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Meteor Missile" 7
 		"Blaster Turret"
 		"Tractor Beam"
 		"D14-RN Shield Generator"
@@ -140,7 +140,7 @@ ship "Argosy" "Argosy (Turret)"
 ship "Arrow" "Arrow (Hai)"
 	outfits
 		"Sidewinder Missile Pod" 2
-		"Sidewinder Missile" 12
+		"Sidewinder Missile" 6
 		"Bullfrog Anti-Missile"
 		"Pebble Core"
 		"Supercapacitor" 2
@@ -202,7 +202,7 @@ ship "Auxiliary" "Auxiliary (Transport)"
 ship "Auxiliary" "Auxiliary (Mark II)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -230,7 +230,7 @@ ship "Auxiliary" "Auxiliary (Cargo Mark II)"
 		"cargo space" 200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -258,7 +258,7 @@ ship "Auxiliary" "Auxiliary (Transport Mark II)"
 		"cargo space" -200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		
@@ -287,7 +287,7 @@ ship "Auxiliary" "Auxiliary (Jump Transport)"
 		"cargo space" -200
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		"Jump Drive"
@@ -319,9 +319,9 @@ ship "Auxiliary" "Auxiliary (Jump Transport)"
 ship "Bactrian" "Bactrian (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Torpedo Launcher"
-		"Torpedo" 30
+		"Torpedo" 15
 		"Heavy Laser Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		"Fusion Reactor"
@@ -577,7 +577,7 @@ ship "Bastion" "Bastion (Scanner)"
 ship "Behemoth" "Behemoth (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Pulse Turret" 6
 		"Boulder Reactor"
 		"Hai Ravine Batteries"
@@ -623,7 +623,7 @@ ship "Behemoth" "Behemoth (Heavy)"
 ship "Behemoth" "Behemoth (Miner)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 90
+		"Meteor Missile" 45
 		"Mining Laser Turret" 4
 		"Tractor Beam" 2
 		
@@ -654,7 +654,7 @@ ship "Behemoth" "Behemoth (Miner)"
 ship "Behemoth" "Behemoth (Proton)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Proton Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		"Breeder Reactor"
@@ -679,7 +679,7 @@ ship "Behemoth" "Behemoth (Proton)"
 ship "Behemoth" "Behemoth (Speedy)"
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Heavy Laser Turret" 6
 		"Breeder Reactor"
 		"LP144a Battery Pack"
@@ -716,7 +716,7 @@ ship "Berserker" "Berserker (Strike)"
 		"Heavy Rocket Pod"
 		"Heavy Rocket" 2
 		"Sidewinder Missile Pod"
-		"Sidewinder Missile" 6
+		"Sidewinder Missile" 3
 		"nGVF-CC Fuel Cell"
 		"Supercapacitor"
 		"D23-QP Shield Generator"
@@ -839,7 +839,7 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 		"Heavy Anti-Missile Turret"
 		"Quad Blaster Turret" 3
 		"Meteor Missile Launcher"
-		"Meteor Missile" 30
+		"Meteor Missile" 15
 		"Fusion Reactor"
 		"LP036a Battery Pack"
 		"D94-YV Shield Generator"
@@ -861,7 +861,7 @@ ship "Bulk Freighter" "Bulk Freighter (Blaster)"
 ship "Bulk Freighter" "Bulk Freighter (Hai)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Pulse Turret" 2
 		"Chameleon Anti-Missile" 3
 		"RT-I Radiothermal"
@@ -886,7 +886,7 @@ ship "Bulk Freighter" "Bulk Freighter (Heavy)"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"KP-6 Photovoltaic Panel" 2
@@ -910,7 +910,7 @@ ship "Bulk Freighter" "Bulk Freighter (Long Haul)"
 		"Anti-Missile Turret" 2
 		"Quad Blaster Turret"
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Fission Reactor"
 		"KP-6 Photovoltaic Panel"
 		"LP144a Battery Pack"
@@ -937,7 +937,7 @@ ship "Bulk Freighter" "Bulk Freighter (Proton)"
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"Water Coolant System"
@@ -960,7 +960,7 @@ ship "Bulwark" "Bulwark (Heavy)"
 	outfits
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 30
 		"Heavy Laser Turret"
 		"Anti-Missile Turret" 2
 		"Fission Reactor"
@@ -1031,10 +1031,11 @@ ship "Carrier" "Carrier (Mark II)"
 	outfits
 		"Typhoon Launcher" 2
 		"Typhoon Torpedo" 60
+		"Typhoon Torpedo" 15
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Sidewinder Missile Rack" 8
-		"Sidewinder Missile" 184
+		"Sidewinder Missile" 92
 		"Electron Turret"
 		"Heavy Anti-Missile Turret" 2
 		"Armageddon Core"
@@ -1070,7 +1071,7 @@ ship "Clipper" "Clipper (Heavy)"
 		"Heavy Rocket Pod" 2
 		"Heavy Rocket" 4
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"RT-I Radiothermal"
 		"Supercapacitor"
 		"D67-TM Shield Generator"
@@ -1155,7 +1156,7 @@ ship "Clipper" "Clipper (Hai Trafficker)"
 
 ship "Combat Drone" "Combat Drone (Sidewinder Missiles)"
 	outfits
-		"Sidewinder Missile" 52
+		"Sidewinder Missile" 26
 		"Sidewinder Missile Pod"
 		"Sidewinder Missile Rack" 2
 		"X1050 Ion Engines"
@@ -1167,7 +1168,7 @@ ship "Container Transport" "Container Transport (Blaster)"
 	outfits
 		"Quad Blaster Turret" 5
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 30
+		"Sidewinder Missile" 15
 		"Fusion Reactor"
 		"LP072a Battery Pack"
 		"D94-YV Shield Generator"
@@ -1183,7 +1184,7 @@ ship "Container Transport" "Container Transport (Blaster)"
 ship "Container Transport" "Container Transport (Hai)"
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Pulse Turret" 3
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -1207,7 +1208,7 @@ ship "Container Transport" "Container Transport (Heavy)"
 		"Heavy Laser Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"KP-6 Photovoltaic Panel" 2
@@ -1231,7 +1232,7 @@ ship "Container Transport" "Container Transport (Proton)"
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"KP-6 Photovoltaic Panel"
@@ -1254,7 +1255,7 @@ ship "Container Transport" "Container Transport (Short Haul)"
 		"Anti-Missile Turret" 2
 		"Blaster Turret" 3
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"RT-I Radiothermal"
 		"KP-6 Photovoltaic Array"
 		"LP036a Battery Pack"
@@ -1293,9 +1294,9 @@ ship "Corvette" "Corvette (Hai)"
 ship "Corvette" "Corvette (Missile)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 30
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 159
+		"Sidewinder Missile" 78
 		"Sidewinder Missile Rack" 3
 		"Anti-Missile Turret"
 		"Heavy Anti-Missile Turret"
@@ -1326,7 +1327,7 @@ ship "Corvette" "Corvette (Raider)"
 		"Torpedo Pod"
 		Torpedo 3
 		"Meteor Missile Launcher"
-		"Meteor Missile" 30
+		"Meteor Missile" 15
 		"Heavy Laser Turret"
 		"Anti-Missile Turret"
 		"KP-6 Photovoltaic Array"
@@ -1362,7 +1363,7 @@ ship "Corvette" "Corvette (Speedy)"
 		"Proton Gun" 4
 		"Heavy Anti-Missile Turret"
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Meteor Missile" 7
 		"Fusion Reactor"
 		"Supercapacitor"
 		"D41-HY Shield Generator"
@@ -1528,9 +1529,9 @@ ship "Cruiser" "Cruiser (Jump)"
 ship "Cruiser" "Cruiser (Mark II)"
 	outfits
 		"Typhoon Launcher" 2
-		"Typhoon Torpedo" 60
+		"Typhoon Torpedo" 15
 		"Sidewinder Missile Launcher" 3
-		"Sidewinder Missile" 134
+		"Sidewinder Missile" 67
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		"Armageddon Core"
@@ -1569,9 +1570,9 @@ ship "Cruiser" "Cruiser (Mark II)"
 ship "Cruiser" "Cruiser (Republic Intelligence)"
 	outfits
 		"Typhoon Launcher" 2
-		"Typhoon Torpedo" 60
+		"Typhoon Torpedo" 15
 		"Sidewinder Missile Launcher" 3
-		"Sidewinder Missile" 134
+		"Sidewinder Missile" 67
 		"Electron Turret" 2
 		"Heavy Anti-Missile Turret" 2
 		"Armageddon Core"
@@ -1702,7 +1703,7 @@ ship "Dagger" "Dagger (Miner)"
 ship "Dreadnought" "Dreadnought (Jump)"
 	outfits
 		"Torpedo Launcher" 4
-		"Torpedo" 120
+		"Torpedo" 60
 		"Plasma Turret" 3
 		"Heavy Anti-Missile Turret" 2
 		"Stack Core"
@@ -1788,9 +1789,9 @@ ship "Enforcer" "Enforcer (CCOR)"
 ship "Falcon" "Falcon (Heavy)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 30
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Fusion Reactor"
@@ -1818,7 +1819,7 @@ ship "Falcon" "Falcon (Prisoner Transport)"
 	outfits
 		"Plasma Cannon" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 30
 		"Quad Blaster Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
@@ -1998,10 +1999,10 @@ ship "Firebird" "Firebird (Laser)"
 ship "Firebird" "Firebird (Missile)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 90
+		"Meteor Missile" 45
 		"Meteor Missile Box" 2
 		"Torpedo Launcher" 2
-		"Torpedo" 75
+		"Torpedo" 37
 		"Torpedo Storage Rack"
 		"Heavy Laser Turret"
 		"Laser Turret"
@@ -2047,7 +2048,7 @@ ship "Firebird" "Firebird (Raider)"
 	outfits
 		"Plasma Cannon" 4
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Meteor Missile" 7
 		"Quad Blaster Turret"
 		"Anti-Missile Turret"
 		"Cargo Expansion" 2
@@ -2111,7 +2112,7 @@ ship "Flivver" "Flivver (Hai)"
 ship "Flivver" "Flivver (Luxury)"
 	outfits
 		"Meteor Missile Pod"
-		"Meteor Missile" 7
+		"Meteor Missile" 3
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"
@@ -2290,7 +2291,7 @@ ship "Frigate" "Frigate (Republic Intelligence)"
 		"Outfit Scanner"
 		"Outfits Expansion"
 		"S-270 Regenerator"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Sidewinder Missile Launcher"
 		Torpedo 30
 		"Torpedo Launcher"
@@ -2331,7 +2332,7 @@ ship "Fury" "Fury (Bomber)"
 		"Heavy Rocket Pod"
 		"Heavy Rocket" 2
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Meteor Missile" 7
 		"nGVF-BB Fuel Cell"
 		"Supercapacitor"
 		"D14-RN Shield Generator"
@@ -2434,7 +2435,7 @@ ship "Fury" "Fury (Missile)"
 		"Javelin Pod"
 		"Javelin" 200
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Meteor Missile" 7
 		"nGVF-BB Fuel Cell"
 		"Supercapacitor" 3
 		"D14-RN Shield Generator"
@@ -2464,7 +2465,7 @@ ship "Fury" "Fury (Raider Missile)"
 		"Javelin Mini Pod"
 		Javelin 30
 		"Meteor Missile Pod"
-		"Meteor Missile" 7
+		"Meteor Missile" 3
 		"KP-6 Photovoltaic Array"
 		"LP072a Battery Pack"
 		"Cargo Expansion"
@@ -2513,7 +2514,7 @@ ship "Gunboat" "Gunboat (Mark II)"
 ship "Hauler" "Hauler (Hai)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Quad Blaster Turret" 2
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -2553,7 +2554,7 @@ ship "Hauler II" "Hauler II (CCOR)"
 ship "Hauler II" "Hauler II (Hai)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Quad Blaster Turret" 2
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -2576,7 +2577,7 @@ ship "Hauler II" "Hauler II (Hai)"
 ship "Hauler III" "Hauler III (Hai)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Quad Blaster Turret" 2
 		"Chameleon Anti-Missile" 2
 		"Geode Reactor"
@@ -2601,7 +2602,7 @@ ship "Hawk" "Hawk (Bomber)"
 		"Heavy Rocket Pod"
 		"Heavy Rocket" 2
 		"Torpedo Pod"
-		"Torpedo" 3
+		"Torpedo" 1
 		"nGVF-CC Fuel Cell"
 		"Supercapacitor"
 		"D41-HY Shield Generator"
@@ -2771,7 +2772,7 @@ ship "Headhunter" "Headhunter (Tractor Beam)"
 	outfits
 		"Twin Modified Blaster" 2
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 29
+		"Meteor Missile" 14
 		"Meteor Missile Box"
 		"Tractor Beam"
 		"RT-I Radiothermal"
@@ -2892,9 +2893,9 @@ ship "Leviathan" "Leviathan (Hai Weapons)"
 ship "Leviathan" "Leviathan (Heavy)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 30
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Breeder Reactor"
@@ -2994,10 +2995,10 @@ ship "Manta" "Manta (Mark II)"
 	outfits
 		"Proton Gun" 4
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Torpedo Pod"
 		"Torpedo Storage Rack"
-		"Torpedo" 18
+		"Torpedo" 9
 		"Fission Reactor"
 		"LP072a Battery Pack"
 		"S-270 Regenerator"
@@ -3041,7 +3042,7 @@ ship "Manta" "Manta (Nuclear)"
 ship "Manta" "Manta (Proton)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Proton Gun" 4
 		"RT-I Radiothermal"
 		"LP144a Battery Pack"
@@ -3068,7 +3069,7 @@ ship "Manta" "Manta (Miner)"
 		"LP036a Battery Pack"
 		"LP072a Battery Pack"
 		"Laser Rifle"
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Meteor Missile Launcher" 2
 		"NT-200 Nucleovoltaic"
 		Supercapacitor 4
@@ -3241,10 +3242,10 @@ ship "Modified Argosy" "Modified Argosy (Javelin)"
 ship "Modified Argosy" "Modified Argosy (Missile)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 105
+		"Meteor Missile" 52
 		"Meteor Missile Box" 3
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 30
 		"Laser Turret"
 		"Heavy Anti-Missile Turret"
 		"S3 Thermionic"
@@ -3279,7 +3280,7 @@ ship "Modified Argosy" "Modified Argosy (Smuggler)"
 ship "Mule" "Mule (Hai Engines)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Heavy Laser Turret" 2
 		"Laser Turret"
 		"Chameleon Anti-Missile"
@@ -3339,7 +3340,7 @@ ship "Mule" "Mule (Hai Weapons)"
 ship "Mule" "Mule (Heavy)"
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Heavy Laser Turret" 3
 		"Heavy Anti-Missile Turret"
 		"Fission Reactor"
@@ -3360,7 +3361,7 @@ ship "Mule" "Mule (Heavy)"
 ship "Nest" "Nest (Miner)"
 	outfits
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"Mining Laser Turret"
 		"Tractor Beam" 2
 		"Heavy Anti-Missile Turret"
@@ -3389,7 +3390,7 @@ ship "Nest" "Nest (Miner)"
 ship "Nest" "Nest (Sidewinder)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Anti-Missile Turret"
 		"Heavy Anti-Missile Turret"
@@ -3505,7 +3506,7 @@ ship "Osprey" "Osprey (Laser)"
 ship "Osprey" "Osprey (Missile)"
 	outfits
 		"Torpedo Launcher" 2
-		"Torpedo" 60
+		"Torpedo" 30
 		"Heavy Rocket Launcher" 2
 		"Heavy Rocket" 40
 		"Heavy Laser Turret"
@@ -3556,7 +3557,7 @@ ship "Osprey" "Osprey (Particle Anti-Missile)"
 ship "Protector" "Protector (Laser)"
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Anti-Missile Turret" 2
 		"Heavy Laser Turret" 4
 		"Fusion Reactor"
@@ -3584,7 +3585,7 @@ ship "Protector" "Protector (Laser)"
 ship "Protector" "Protector (Proton)"
 	outfits
 		"Sidewinder Missile Launcher"
-		"Sidewinder Missile" 45
+		"Sidewinder Missile" 22
 		"Proton Turret" 4
 		"Heavy Anti-Missile Turret" 2
 		"Fusion Reactor"
@@ -3627,7 +3628,7 @@ ship "Protector" "Protector (Quad Blaster)"
 ship "Protector" "Protector (Tractor Beam)"
 	outfits
 		"Torpedo Launcher"
-		"Torpedo" 30
+		"Torpedo" 15
 		"Quad Blaster Turret" 4
 		"Anti-Missile Turret" 2
 		"Tractor Beam" 2
@@ -3713,7 +3714,7 @@ ship "Quicksilver" "Quicksilver (Scanner)"
 ship "Rainmaker" "Rainmaker (Mark II)"
 	outfits
 		"Sidewinder Missile Launcher" 3
-		"Sidewinder Missile" 135
+		"Sidewinder Missile" 67
 		"nGVF-CC Fuel Cell"
 		"LP036a Battery Pack"
 		"D67-TM Shield Generator"
@@ -3736,7 +3737,7 @@ ship "Rainmaker" "Rainmaker (Mark II Old Weapons)"
 	outfits
 		"Energy Blaster" 2
 		"Meteor Missile Launcher" 4
-		"Meteor Missile" 180
+		"Meteor Missile" 90
 		"Meteor Missile Box" 4
 		"Dwarf Core"
 		"Supercapacitor"
@@ -3769,10 +3770,10 @@ ship "Raven" "Raven (Heavy)"
 		"Twin Modified Blaster" 4
 		"Meteor Missile Launcher"
 		"Meteor Missile Box"
-		"Meteor Missile" 45
+		"Meteor Missile" 22
 		"Torpedo Pod"
 		"Torpedo Storage Rack"
-		"Torpedo" 18
+		"Torpedo" 9
 		"Outfits Expansion"
 		"Fission Reactor"
 		"LP036a Battery Pack"
@@ -3789,7 +3790,7 @@ ship "Raven" "Raven (Heavy)"
 ship "Roost" "Roost (Sidewinder)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
@@ -3811,7 +3812,7 @@ ship "Saber" "Saber (CCOR Gatling)"
 		"Gatling Turret"
 		"Gatling Gun Ammo" 6000
 		"Meteor Missile Launcher" 2
-		"Meteor Missile" 60
+		"Meteor Missile" 30
 		"nGVF-BB Fuel Cell"
 		"LP072a Battery Pack"
 		"D23-QP Shield Generator"
@@ -3846,9 +3847,9 @@ ship "Saber" "Saber (CCOR Javelin)"
 ship "Scout" "Scout (Speedy)"
 	outfits
 		"Meteor Missile Pod"
-		"Meteor Missile" 7
+		"Meteor Missile" 3
 		"Sidewinder Missile Pod"
-		"Sidewinder Missile" 6
+		"Sidewinder Missile" 3
 		"Anti-Missile Turret"
 		"NT-200 Nucleovoltaic"
 		"Supercapacitor"
@@ -3902,7 +3903,7 @@ ship "Scrapper" "Scrapper (Mod Blaster)"
 ship "Skein" "Skein (Sidewinder)"
 	outfits
 		"Sidewinder Missile Launcher" 2
-		"Sidewinder Missile" 90
+		"Sidewinder Missile" 45
 		"Quad Blaster Turret" 2
 		"Heavy Anti-Missile Turret"
 		"Anti-Missile Turret"
@@ -3985,7 +3986,7 @@ ship "Splinter" "Splinter (Mark II)"
 		"Quad Blaster Turret" 2
 		"Meteor Missile Pod" 2
 		"Meteor Missile Box"
-		"Meteor Missile" 29
+		"Meteor Missile" 14
 		"Fusion Reactor"
 		"LP036a Battery Pack"
 		"S-970 Regenerator"
@@ -4146,7 +4147,7 @@ ship "Sunder" "Sunder (Heavy)"
 ship "Vanguard" "Vanguard (Missile)"
 	outfits
 		"Sidewinder Missile Launcher" 4
-		"Sidewinder Missile" 226
+		"Sidewinder Missile" 113
 		"Sidewinder Missile Rack" 2
 		"Torpedo Launcher" 3
 		"Torpedo" 90
@@ -4237,7 +4238,7 @@ ship "Wasp" "Wasp (Meteor)"
 	outfits
 		"Energy Blaster"
 		"Meteor Missile Pod" 2
-		"Meteor Missile" 14
+		"Meteor Missile" 7
 		"nGVF-BB Fuel Cell"
 		"LP036a Battery Pack"
 		"D14-RN Shield Generator"

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -116,7 +116,7 @@ ship "Albatross" "Albatross (Sniper)"
 		"Inhibitor Cannon" 5
 		"EMP Torpedo Bay" 2
 		"Point Defense Turret" 3
-		"EMP Torpedo" 39
+		"EMP Torpedo" 18
 		"EMP Torpedo Storage Bay" 3
 
 		"Aeon Cell"
@@ -661,7 +661,7 @@ ship "Gull" "Gull (Support)"
 		"EMP Torpedo Bay"
 		"Inhibitor Cannon" 2
 		"Point Defense Turret"
-		"EMP Torpedo" 16
+		"EMP Torpedo" 8
 		"EMP Torpedo Storage Bay"
 
 		"Epoch Cell"
@@ -1451,7 +1451,7 @@ ship "Peregrine"
 		"EMP Torpedo Bay" 1
 		"Point Defense Turret"
 		"Thrasher Turret"
-		"EMP Torpedo" 9
+		"EMP Torpedo" 5
 		
 		"Aeon Cell"
 		"Crystal Capacitor" 2
@@ -1876,7 +1876,7 @@ ship "Starling" "Starling (Sniper)"
 	outfits
 		"EMP Torpedo Bay"
 		"Inhibitor Cannon" 4
-		"EMP Torpedo" 16
+		"EMP Torpedo" 8
 		"EMP Torpedo Storage Bay"
 
 		"Epoch Cell"

--- a/data/successors/successor ships.txt
+++ b/data/successors/successor ships.txt
@@ -233,7 +233,7 @@ ship "Kaskhorade"
 	outfits
 		`"Ojet" Bimodal Coilgun` 2
 		`"Sjeja" Kinetic Lance` 2
-		"High-Velocity Spike" 40
+		"High-Velocity Spike" 20
 		"Bimodal Coilgun Turret"
 
 		`"Uoret" Fusion Core`

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -134,7 +134,6 @@ ship "Summer Leaf"
 		
 		"Yellow Sun Reactor"
 		"Small Biochemical Cell"
-		"Bright Cloud Shielding"
 		"Wanderer Ramscoop"
 		
 		"Type 3 Radiant Thruster"
@@ -191,7 +190,6 @@ ship "Autumn Leaf"
 		"Wanderer Anti-Missile"
 		
 		"White Sun Reactor"
-		"Bright Cloud Shielding"
 		"Wanderer Ramscoop"
 		
 		"Type 3 Radiant Thruster"
@@ -262,11 +260,9 @@ ship "Strong Wind"
 	outfits
 		"Sunbeam" 4
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 100
-		"Thunderhead Storage Array"
+		"Thunderhead Missile" 40
 		
 		"White Sun Reactor"
-		"Dark Storm Shielding"
 		"Wanderer Ramscoop" 2
 		
 		"Type 3 Radiant Thruster"
@@ -322,12 +318,11 @@ ship "Tempest"
 	outfits
 		"Sunbeam" 2
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 80
+		"Thunderhead Missile" 40
 		"Dual Sunbeam Turret"
 		"Wanderer Anti-Missile" 2
 		
 		"Yellow Sun Reactor" 2
-		"Dark Storm Shielding"
 		"Wanderer Ramscoop"
 		
 		"Type 4 Radiant Thruster"
@@ -379,7 +374,7 @@ ship "Tempest" "Tempest (Heavy)"
 ship "Tempest" "Tempest (Missile)"
 	outfits
 		"Thunderhead Launcher" 4
-		"Thunderhead Missile" 220
+		"Thunderhead Missile" 110
 		"Thunderhead Storage Array" 3
 		"Dual Sunbeam Turret" 2
 		
@@ -457,14 +452,12 @@ ship "Derecho"
 	outfits
 		"Sunbeam" 2
 		"Thunderhead Launcher" 2
-		"Thunderhead Missile" 80
+		"Thunderhead Missile" 40
 		"Dual Sunbeam Turret" 2
 		"Wanderer Anti-Missile" 2
 		
 		"Blue Sun Reactor"
 		"Red Sun Reactor"
-		"Dark Storm Shielding"
-		"Bright Cloud Shielding"
 		"Wanderer Heat Sink"
 		"Wanderer Ramscoop"
 		
@@ -601,7 +594,6 @@ ship "Hurricane"
 		
 		"Blue Sun Reactor"
 		"White Sun Reactor"
-		"Dark Storm Shielding" 2
 		"Wanderer Heat Sink"
 		"Wanderer Ramscoop"
 		
@@ -655,7 +647,7 @@ ship "Hurricane" "Hurricane (Tough)"
 	outfits
 		"Sunbeam" 2
 		"Thunderhead Launcher" 4
-		"Thunderhead Missile" 160
+		"Thunderhead Missile" 80
 		"Dual Sunbeam Turret" 2
 		"Wanderer Anti-Missile" 2
 		
@@ -759,7 +751,6 @@ ship "Cool Breeze"
 		"Moonbeam" 2
 		
 		"Red Sun Reactor"
-		"Bright Cloud Shielding"
 		
 		"Type 2 Radiant Thruster"
 		"Type 2 Radiant LTC"
@@ -826,7 +817,6 @@ ship "Winter Gale"
 		"Wanderer Anti-Missile"
 		
 		"White Sun Reactor"
-		"Dark Storm Shielding"
 		
 		"Type 3 Radiant Thruster"
 		"Type 3 Radiant LTC"
@@ -881,7 +871,7 @@ ship "Winter Gale" "Winter Gale (Heavy)"
 ship "Winter Gale" "Winter Gale (Missile)"
 	outfits
 		"Thunderhead Launcher" 4
-		"Thunderhead Missile" 160
+		"Thunderhead Missile" 80
 		"Moonbeam" 2
 		"Wanderer Anti-Missile"
 		
@@ -940,11 +930,9 @@ ship "Deep River"
 			"hit force" 4200
 	outfits
 		"Thunderhead Launcher" 6
-		"Thunderhead Missile" 320
-		"Thunderhead Storage Array" 4
+		"Thunderhead Missile" 120
 		
 		"Large Biochemical Cell"
-		"Bright Cloud Shielding"
 		"Wanderer Ramscoop"
 		
 		"Type 2 Radiant Thruster"
@@ -1044,7 +1032,6 @@ ship "Deep River Transport"
 		"Wanderer Anti-Missile" 4
 		
 		"Yellow Sun Reactor"
-		"Dark Storm Shielding"
 		"Wanderer Ramscoop"
 		
 		"Type 2 Radiant Thruster"
@@ -1116,7 +1103,6 @@ ship "Riptide"
 		"Wanderer Anti-Missile" 2
 		
 		"White Sun Reactor"
-		"Bright Cloud Shielding"
 		"Wanderer Ramscoop"
 		
 		"Type 4 Radiant Thruster"

--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -4386,7 +4386,7 @@ int Ship::StepDestroyed(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flot
 				// Negative values override the default chance for ammunition
 				// so the outfit cannot be dropped as flotsam.
 				else if(it.first->Category() == "Ammunition" && !flotsamChance)
-					Jettison(it.first, Random::Binomial(it.second, .05));
+					Jettison(it.first, Random::Binomial(it.second, .10));
 			}
 			for(shared_ptr<Flotsam> &it : jettisoned)
 				it->Place(*this);


### PR DESCRIPTION
**Content/Balance/Fix**

## Summary
There's a lot of problems with how ships are current outfitted stock, as well as how they interact with the player in-game. 

## Problems:
- Ships are purchased in optimized form. As in, there is little to no capacity for the player to make changes without ripping *something* out.
- Poor player engagement. Ships rarely feel special or unique to the player, often leaving the player feeling they're just flying basically a carbon copy ship out of the shipyard.
- Ships are expensive to buy, which is particularly problematic when the player doesn't actually want a lot of the stuff on it. Many players have asked for a way to buy the bare hull.
- NPC vs Player fairness: NPCs are spawned with full health, full ammo, and ready to go. Player may have just been through a battle, or three, and may not have any ammo left at all. 
- Differentiation: If every ship is sold stock ready for combat, then ships that are designed to give a combat edge (like the argosy) don't stand out nearly as much as they really should. 

## Changes:
One "Code" change:
- The default ammo drop rate, which is the rate that ammo on a destroyed ship is dropped, has been bumped up from 5% to 10%. I think this should also  help with logistics and resupply by giving players a little bit more opportunity to pick up ammo, if they are so inclined.

Note: While described in broad terms, none of these are applied in hard rules. There are exceptions. 
**Currently, these changes apply to stock ships only:**
- Shield generators removed from non-combat ships.
- Non-carriers have had their shield generators downgraded one step.
- Secondary generators removed.
- Non-carriers have had ammo racks removed.
- Ammunition present set to half their ammo capacity.

**Changes to variants:**
- Currently, no direct changes to variants. 
- Only changes that trickle down from the original ship. This means that any variant that specifies its own independent outfit loadout is going to be unchanged, whereas variants that basically use the original stock version's loadout *will* be changed.

Planned: Variants will largely get the same change to ammo, for the same reason (unless its a variant specifically used in a mission that depicts it taking off with the player and thus reasonably assume it to be full ammo).

## Intended impacts:
- Ships should be cheaper to buy.
- Ships should have space for the player to install things immediately, without needing to sell something.
- Players should feel like they are making the ship theirs, instead of just running with the configuration someone already decided was a good configuration.
- Shield regeneration is a choice, not a default, for ships that aren't combat oriented. 
- Having good shield regeneration vs merely "will recover over time / outside of combat" is a choice, not a default.
- Hit and run tactics should be doable against most stock ships, but will continue to be virtually useless against a few of them, namely the carriers. This should help carriers stand out a bit more, too.
- Having extra ammo is an after-market add-on for most ships, not an essential piece of starting equipment. (exception: Rainmaker and carriers that need that capacity for their core purpose and re-arming)
- NPCs should feel like they, too, operate in a dangerous galaxy and have expended some resources.
- Argosy is more noteworthy for its out-of-the-box combat resilience.
- Variants are going to be much more noteworthy. Regular ship is going to be easier to fight than a variant version in most cases.

## Notes &  Caveats:
- NO CHANGES TO THE HULL ITSELF. This means that there has been absolutely zero change to any ship's *potential* in the hands of the player. If you could outfit a ship a certain way in Delta before this PR, you can do it in Delta after this PR. 
- This PR only changes how ships are outfitted.

## Testing Done
none yet.
