### PR TITLE
Feat(data): Human Price Changes

### DIFF
--- a/data/custom sales.txt
+++ b/data/custom sales.txt
@@ -16,63 +16,72 @@ pricing outfits "Quarg Technology Friendly Groups"
 	location
 		government "Free Worlds" "Hai" "Neutral" "Republic" "Syndicate"
 	offset
-		"Nanotech Battery" -0.9 %
-		"Antimatter Core" -0.9 %
+		"Skydagger" -0.9 %
+		"Skylance" -0.9 %
 		"Quarg Skylance" -0.9 %
+		"Stratospear" -0.9 %
 		"Quarg Anti-Missile" -0.9 %
-		"Intrusion Countermeasures" -0.9 %
+		"Elysian Ranseur" -0.9 %
+		"Celestial Culverin" -0.9 %
+		"Astral Ribault" -0.9 %
+		"Slipstream Projector" -0.9 %
+		"Nanotech Battery" -0.9 %
+		"Quantum Vacuum Battery" -0.9 %
+		"Antimatter Core" -0.9 %
+		"Singularity Core" -0.9 %
+		"Quasar Core" -0.9 %
+		"Antimatter Core" -0.9 %
+		"Aspis Shield Generator" -0.9 %
+		"Ancile Shield Generator" -0.9 %
+		"Aegis Shield Generator" -0.9 %
+		"Peripheral Repair Hub" -0.9 %
+		"Central Repair Hub" -0.9 %
+		"Quantum Shield Generator" -0.9 %
+		"Small Graviton Thruster" -0.9 %
+		"Small Graviton Steering" -0.9 %
+		"Small Graviton LTC" -0.9 %
 		"Medium Graviton Thruster" -0.9 %
 		"Medium Graviton Steering" -0.9 %
-		"Quantum Shield Generator" -0.9 %
+		"Medium Graviton LTC" -0.9 %
+		"Large Graviton Thruster" -0.9 %
+		"Large Graviton Steering" -0.9 %
+		"Large Graviton LTC" -0.9 %
+		"Intrusion Countermeasures" -0.9 %
+		"Phalanx System" -0.9 %
 
 pricing outfits "Quarg Technology Hostile Groups"
 	location
 		government "Hai (Unfettered)" "Independent" "Pirate"
 	offset
-		"Nanotech Battery" 3 %
-		"Antimatter Core" 3 %
-		"Quarg Skylance" 3 %
-		"Quarg Anti-Missile" 3 %
-		"Intrusion Countermeasures" 3 %
-		"Medium Graviton Thruster" 3 %
-		"Medium Graviton Steering" 3 %
-		"Quantum Shield Generator" 3 %
-
-
-pricing outfits "Remnant Hai Keystones"
-	import
-	location
-		government "Remnant"
-	conditions
-		or
-			has "Remnant: Key Stones: done"
-			has "Remnant: Key Stones (Pre-Hai) 2: done"
-	value
-		"Quantum Keystone" 200000
-
-# These are outfits that the Remnant value and want to see imported.
-pricing outfits "Remnant Valued Tech"
-	import
-	location
-		government "Remnant"
-	value
-		"Jump Drive" 2500000
-	offset
-		"Nanotech Battery" 3.5 %
-		"Antimatter Core" 3.5 %
-		"Quarg Skylance" 3.5 %
-		"Quarg Anti-Missile" 3.5 %
-		"Intrusion Countermeasures" 3 %
-		"Medium Graviton Thruster" 3.5 %
-		"Medium Graviton Steering" 3.5 %
-		"Quantum Shield Generator" 3.5 %
-
-# These are old outfits that the Remnant do not use much, and thus do not value as much as elsewhere.
-pricing outfits "Remnant Old Tech"
-	location
-		government "Remnant"
-	value
-		"Cargo Scanner" 5000
-		"Outfit Scanner" 18000
-		"Hyperdrive" 30000
-	
+		"Skydagger" 2.5 %
+		"Skylance" 2.5 %
+		"Quarg Skylance" 2.5 %
+		"Stratospear" 2.5 %
+		"Quarg Anti-Missile" 2.5 %
+		"Elysian Ranseur" 2.5 %
+		"Celestial Culverin" 2.5 %
+		"Astral Ribault" 2.5 %
+		"Slipstream Projector" 2.5 %
+		"Nanotech Battery" 2.5 %
+		"Quantum Vacuum Battery" 2.5 %
+		"Antimatter Core" 2.5 %
+		"Singularity Core" 2.5 %
+		"Quasar Core" 2.5 %
+		"Antimatter Core" 2.5 %
+		"Aspis Shield Generator" 2.5 %
+		"Ancile Shield Generator" 2.5 %
+		"Aegis Shield Generator" 2.5 %
+		"Peripheral Repair Hub" 2.5 %
+		"Central Repair Hub" 2.5 %
+		"Quantum Shield Generator" 2.5 %
+		"Small Graviton Thruster" 2.5 %
+		"Small Graviton Steering" 2.5 %
+		"Small Graviton LTC" 2.5 %
+		"Medium Graviton Thruster" 2.5 %
+		"Medium Graviton Steering" 2.5 %
+		"Medium Graviton LTC" 2.5 %
+		"Large Graviton Thruster" 2.5 %
+		"Large Graviton Steering" 2.5 %
+		"Large Graviton LTC" 2.5 %
+		"Intrusion Countermeasures" 2.5 %
+		"Phalanx System" 2.5 %

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -780,12 +780,12 @@ outfitter "Nuke"
 
 
 
-# Most standard outfitters are regular commercial enterprises that aren't interested in random alien technology. They mostly want to sell the player stuff, not be a source of profit for someone looting scrap metal from who knows where. Some, however, particularly R&D and independently-minded places, should be more interested. Tarazed and New Tortuga come to mind, probably a few others out there too.
+# Most standard outfitters are regular commercial enterprises that aren't interested in random alien technology. They mostly want to sell the player stuff, not be a source of profit for someone looting weird scrap metal from who knows where. Some, however, particularly R&D and independently-minded places, should be more interested. Wayfarer, New Tortuga, and Cratz come to mind, probably a few others out there too.
 pricing outfits "Human Not Interested in Alien Tech"
 	import
 	location
 		government "Free Worlds" "Neutral" "Republic" "Syndicate"
-		not planet "Tarazed" "New Tortuga"
+		not planet "Wayfarer" "New Tortuga" "Rust"
 	value
 		# Rulei Outfits
 		"Fate Sealer" 1
@@ -1074,11 +1074,12 @@ pricing outfits "Human Not Interested in Alien Tech"
 
 
 		
-
+# While the Hai are unknown, regular outfitters shouldn't be interested in them. Once the treaty is signed, though, and trade relations start to normalize, these will start becoming regular things. So this price penalty will apply up until the treaty is signed, and after that, vanish.
 pricing outfits "Hai outfits in human space"
 	import
 	location
-		government "Republic"
+		government "Free Worlds" "Neutral" "Republic" "Syndicate"
+		not event "hai-human treaty signed"
 	offset		
 		# Hai Outfits
 		"Boulder Reactor" -0.5 %

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -1080,7 +1080,7 @@ pricing outfits "Hai outfits in human space"
 	location
 		government "Free Worlds" "Neutral" "Republic" "Syndicate"
 	conditions
-		not event "hai-human treaty signed"
+		not "event: hai-human treaty signed"
 	offset
 		# Hai Outfits
 		"Boulder Reactor" -0.5 %

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -776,3 +776,352 @@ outfitter "Stack Core"
 
 outfitter "Nuke"
 	"Nuclear Missile"
+
+
+
+
+# Most standard outfitters are regular commercial enterprises that aren't interested in random alien technology. They mostly want to sell the player stuff, not be a source of profit for someone looting scrap metal from who knows where. Some, however, particularly R&D and independently-minded places, should be more interested. Tarazed and New Tortuga come to mind, probably a few others out there too.
+pricing outfits "Human Not Interested in Alien Tech"
+	import
+	location
+		government "Free Worlds" "Neutral" "Republic" "Syndicate"
+		not planet "Tarazed" "New Tortuga"
+	value
+		# Rulei Outfits
+		"Fate Sealer" 1
+		"Fate Divider" 1
+		"Abyssal Composer" 1
+	offset
+		# Avgi Outfits
+		`"Nettle" KKV` -0.5 %
+		`"Ophrys" Nuclear Torpedo` -0.5 %
+		`"Orchid" Nuclear Missile` -0.5 %
+		`Z-333 "Spark" Fusion Torch` -0.5 %
+		`Z-666 "Zap" Fusion Torch` -0.5 %
+		`Z-999 "Arc" Fusion Torch` -0.5 %
+		"Blue Optical Laser" -0.5 %
+		"Concealment Lamina" -0.5 %
+		"Concentrating Solar Array" -0.5 %
+		"Concentrating Solar Cell" -0.5 %
+		"Cryogenic Deuterium Tank" -0.5 %
+		"Deuterium Slush Tank" -0.5 %
+		"Diffuse Deflector" -0.5 %
+		"External Launch Rail" -0.5 %
+		"External Launch Tube" -0.5 %
+		"Green Optical Laser" -0.5 %
+		"Heatsink Partition" -0.5 %
+		"Inductive Extractor" -0.5 %
+		"Lantern Fission Core" -0.5 %
+		"Magnetic Scoop" -0.5 %
+		"Magnetoplasma Drive" -0.5 %
+		"Medium VLS" -0.5 %
+		"Multispectral Scanner" -0.5 %
+		"Nettle Magazine" -0.5 %
+		"Ophrys Stockpile" -0.5 %
+		"Optical Lasing Generator" -0.5 %
+		"Orchid Magazine" -0.5 %
+		"Photoelectric Lamina" -0.5 %
+		"Plasmadyne Scoop" -0.5 %
+		"R-180 RCS Thrusters" -0.5 %
+		"R-360 RCS Thrusters" -0.5 %
+		"R-720 RCS Thrusters" -0.5 %
+		"Radiative Lamina" -0.5 %
+		"Remass Injector" -0.5 %
+		"Speck Magazine" -0.5 %
+		"Speck Round" -0.5 %
+		"Speckle Coilgun" -0.5 %
+		"Speckle Turret" -0.5 %
+		"Spectrometer Array" -0.5 %
+		"Specular Deflector" -0.5 %
+		"Ultracapacitor Bank" -0.5 %
+		"Ultracapacitor Cell" -0.5 %
+		# Bunrodea Outfits
+		"Buzzer Anti-Missile" -0.5 %
+		"Chiisana Rift Steering" -0.5 %
+		"Chiisana Rift Thruster" -0.5 %
+		"Dark Reactor" -0.5 %
+		"Electroweak Reactor" -0.5 %
+		"Large Nanite Fabricator" -0.5 %
+		"Large Shield Relay" -0.5 %
+		"Lasher Pistol" -0.5 %
+		"Locust Blaster" -0.5 %
+		"Locust Turret" -0.5 %
+		"Mandible Cannon" -0.5 %
+		"Nami Rift Steering" -0.5 %
+		"Nami Rift Thruster" -0.5 %
+		"Nanite Enhancer" -0.5 %
+		"Nanite Limiter" -0.5 %
+		"Ookii Rift Steering" -0.5 %
+		"Ookii Rift Thruster" -0.5 %
+		"Outfits Expansion" -0.5 %
+		"Quark Reactor" -0.5 %
+		"Reactor Limiter" -0.5 %
+		"Reactor Overclocker" -0.5 %
+		"Shield Relay Booster" -0.5 %
+		"Shield Relay Limiter" -0.5 %
+		"Small Bunk Room" -0.5 %
+		"Small Nanite Fabricator" -0.5 %
+		"Small Shield Relay" -0.5 %
+		"Solar Battery" -0.5 %
+		"Solar Cell" -0.5 %
+		"Subarashii Rift Steering" -0.5 %
+		"Subarashii Rift Thruster" -0.5 %
+		"Swarm Clip" -0.5 %
+		"Swarm Missile" -0.5 %
+		"Swarm Pod" -0.5 %
+		"Thorax Cannon" -0.5 %
+		# Coalition Outfits
+		"Anti-Materiel Gun" -0.5 %
+		"Bombardment Cannon" -0.5 %
+		"Bombardment Turret" -0.5 %
+		"Cooling Module" -0.5 %
+		"Decoy Plating" -0.5 %
+		"Enforcer Confrontation Gear" -0.5 %
+		"Enforcer Riot Staff" -0.5 %
+		"Finisher Pod" -0.5 %
+		"Finisher Torpedo" -0.5 %
+		"Fuel Module" -0.5 %
+		"Heliarch Attractor" -0.5 %
+		"Heliarch Repulsor" -0.5 %
+		"Ion Hail Turret" -0.5 %
+		"Ion Rain Gun" -0.5 %
+		"Large Battery Module" -0.5 %
+		"Large Cogeneration Module" -0.5 %
+		"Large Collector Module" -0.5 %
+		"Large Lateral Thrust Module" -0.5 %
+		"Large Reactor Module" -0.5 %
+		"Large Repair Module" -0.5 %
+		"Large Reverse Module" -0.5 %
+		"Large Shield Module" -0.5 %
+		"Large Steering Module" -0.5 %
+		"Large Thrust Module" -0.5 %
+		"MCS Extractor" -0.5 %
+		"Refueling Module" -0.5 %
+		"Scanning Module" -0.5 %
+		"Shield Refactor Module" -0.5 %
+		"Small Battery Module" -0.5 %
+		"Small Cogeneration Module" -0.5 %
+		"Small Collector Module" -0.5 %
+		"Small Lateral Thrust Module" -0.5 %
+		"Small Reactor Module" -0.5 %
+		"Small Recovery Module" -0.5 %
+		"Small Repair Module" -0.5 %
+		"Small Reverse Module" -0.5 %
+		"Small Shield Module" -0.5 %
+		"Small Steering Module" -0.5 %
+		"Small Thrust Module" -0.5 %
+		# Gegno Outfits
+		"Acuit Artillery" -0.5 %
+		"Astuit Battery" -0.5 %
+		"Ballistic Cannon Turret" -0.5 %
+		"Ballistic Cannon" -0.5 %
+		"C17 Warzone Core" -0.5 %
+		"C27 Campaign Core" -0.5 %
+		"C3 Scrap Cell" -0.5 %
+		"C7 Brawl Cell" -0.5 %
+		"Choleric Cannon Turret" -0.5 %
+		"Choleric Cannon" -0.5 %
+		"Guile Pulse Laser" -0.5 %
+		"I70 Ameliorate Cell" -0.5 %
+		"Irate Cannon Turret" -0.5 %
+		"Irate Cannon" -0.5 %
+		"R01 Skirmish Battery" -0.5 %
+		"R02 Battlezone Battery" -0.5 %
+		"R03 Warforge Battery" -0.5 %
+		"R04 Crusade Battery" -0.5 %
+		"RG15 Torch Steering" -0.5 %
+		"RG15 Torch Thruster" -0.5 %
+		"RG18 Torch Steering" -0.5 %
+		"RG18 Torch Thruster" -0.5 %
+		"RG3 Torch Steering" -0.5 %
+		"RG3 Torch Thruster" -0.5 %
+		"SC-1 Plasma Engines" -0.5 %
+		"SC-12 Plasma Steering" -0.5 %
+		"SC-12 Plasma Thruster" -0.5 %
+		"SC-14 Plasma Steering" -0.5 %
+		"SC-14 Plasma Thruster" -0.5 %
+		"SC-15 Plasma Thrusters" -0.5 %
+		# Incipias Outfits
+		"Plasma Discharger" -0.5 %
+		"Stagnation Beam" -0.5 %
+		"Horizon Grappler" -0.5 %
+		"Gas-Class Shield" -0.5 %
+		"Liquid-Class Shield" -0.5 %
+		"Metallic Hydrogen Cell" -0.5 %
+		"Cloud Piercer" -0.5 %
+		"MH Blue-Class Thruster" -0.5 %
+		"MH Blue-Class Steering" -0.5 %
+		"MH Green-Class Thruster" -0.5 %
+		"MH Green-Class Steering" -0.5 %
+		"MH Red-Class Thruster" -0.5 %
+		"MH Red-Class Steering" -0.5 %
+		# Sheragi Outfits
+		"Small EM Battery" -0.5 %
+		"Large EM Battery" -0.5 %
+		"Small Hybrid Cooling" -0.5 %
+		"Large Hybrid Cooling" -0.5 %
+		"Fission Drive" -0.5 %
+		"Fusion Drive" -0.5 %
+		"Electronic Warfare System" -0.5 %
+		"Dragonflame Cannon" -0.5 %
+		"Sheragi Anti-Missile" -0.5 %
+		"Particle Waveform Turret" -0.5 %
+		"Shard Fabricator" -0.5 %
+		"Heavy Ion Cyclotron" -0.5 %
+		# Successors Outfits
+		"Auxiliary Power Reserve" -0.5 %
+		"Bimodal Coilgun Turret" -0.5 %
+		"Drag Cannon" -0.5 %
+		"High-Velocity Spike Rack" -0.5 %
+		"High-Velocity Spike" -0.5 %
+		"Kinetic Rail Rifle" -0.5 %
+		# Note: the Multimodal armor is not actually an outfit, but rather a mode for successor ship's armor. Thus selling it is just letting it revert to normal, there's no actual thing to sell.
+		"Multimodal Armor: Keystone" -1 %
+		"Multimodal Armor: Heavy" -1 %
+		"Multimodal Armor: Regen" -1 %
+		"Multimodal Armor: Resilient" -1 %
+		"Overcharged Laser Turret" -0.5 %
+		"Overcharged Pulse Laser" -0.5 %
+		"Primary Power Reserve" -0.5 %
+		"Pulse Laser Turret" -0.5 %
+		"Shield Cortex Interface" -0.5 %
+		"Successor Cooling" -0.5 %
+		"Successor Fuel Sail" -0.5 %
+		"Successor Pulse Laser" -0.5 %
+		`"Aqra" Inductive Reverser` -0.5 %
+		`"Aqra" Inductive Steering` -0.5 %
+		`"Aqra" Inductive Thruster` -0.5 %
+		`"Byiaa" Shield Cortex` -0.5 %
+		`"Chyyra" Inductive Reverser` -0.5 %
+		`"Chyyra" Inductive Steering` -0.5 %
+		`"Chyyra" Inductive Thruster` -0.5 %
+		`"Ej" Shield Cortex` -0.5 %
+		`"Jaase" Shield Cortex` -0.5 %
+		`"Jorv" Shield Cortex` -0.5 %
+		`"Niis" Inductive Engines` -0.5 %
+		`"Nnesa" Fusion Core` -0.5 %
+		`"Ojet" Bimodal Coilgun` -0.5 %
+		`"Ryuit" Fusion Core` -0.5 %
+		`"Sjeja" Kinetic Lance` -0.5 %
+		`"Tuur" Scanning Suite` -0.5 %
+		`"Uoret" Fusion Core` -0.5 %
+		`"Veldt" Combat Scanner` -0.5 %
+		`"Veusa" Inductive Reverser` -0.5 %
+		`"Veusa" Inductive Steering` -0.5 %
+		`"Veusa" Inductive Thruster` -0.5 %
+		`1-"Uurau" Betavoltaic Cell` -0.5 %
+		`3-"Kaska" Betavoltaic Cell` -0.5 %
+		`6-"Ruuv" Betavoltaic Cell` -0.5 %
+		`OC-"Mavra" Betavoltaic Cell` -0.5 %
+		# Ka'het Outfits
+		"Ka'het Nullifier" -0.5 %
+		"Ka'het Ravager Beam" -0.5 %
+		"Ka'het Ravager Turret" -0.5 %
+		"Ka'het Annihilator" -0.5 %
+		"Ka'het Annihilator Turret" -0.5 %
+		"Ka'het EMP Deployer" -0.5 %
+		"Ka'het Support Cooling" -0.5 %
+		"Ka'het Primary Cooling" -0.5 %
+		"Ka'het Shield Restorer" -0.5 %
+		"Ka'het Grand Restorer" -0.5 %
+		"Ka'het MHD Generator" -0.5 %
+		"Ka'het Reserve Accumulator" -0.5 %
+		"Maeri Engine Nacelles" -0.5 %
+		"Ka'het Sustainer Nacelles" -0.5 %
+		"Telis Engine Nacelles" -0.5 %
+		"Vareti Engine Block" -0.5 %
+		"Ka'het Compact Engine" -0.5 %
+		# Korath Outfits
+		"Afterburner (Asteroid Class)" -0.5 %
+		"Afterburner (Comet Class)" -0.5 %
+		"Banisher Grav-Turret" -0.5 %
+		"Bow Drive (Meteor Class)" -0.5 %
+		"Cluster Mine Rack" -0.5 %
+		"Command Center" -0.5 %
+		"Digger Mining Beam" -0.5 %
+		"Digger Mining Turret" -0.5 %
+		"Engine (Meteor Class)" -0.5 %
+		"Expeller Grav-Ray" -0.5 %
+		"Fire-Lance" -0.5 %
+		"Firelight Storage Rack" -0.5 %
+		"Firestorm Torpedo Rack" -0.5 %
+		"Fuel Processor" -0.5 %
+		"Generator (Candle Class)" -0.5 %
+		"Generator (Furnace Class)" -0.5 %
+		"Generator (Inferno Class)" -0.5 %
+		"Grab-Strike Turret" -0.5 %
+		"Large Heat Shunt" -0.5 %
+		"Piercer Missile Rack" -0.5 %
+		"Reverser (Asteroid Class)" -0.5 %
+		"Reverser (Comet Class)" -0.5 %
+		"Reverser (Lunar Class)" -0.5 %
+		"Small Heat Shunt" -0.5 %
+		"Steering (Asteroid Class)" -0.5 %
+		"Steering (Comet Class)" -0.5 %
+		"Steering (Lunar Class)" -0.5 %
+		"Steering (Planetary Class)" -0.5 %
+		"Systems Core (Large)" -0.5 %
+		"Systems Core (Medium)" -0.5 %
+		"Systems Core (Small)" -0.5 %
+		"Thermal Repeater Rifle" -0.5 %
+		"Thruster (Asteroid Class)" -0.5 %
+		"Thruster (Comet Class)" -0.5 %
+		"Thruster (Lunar Class)" -0.5 %
+		"Thruster (Planetary Class)" -0.5 %
+		"Triple Plasma Core" -0.5 %
+		"Warder Anti-Missile" -0.5 %
+
+
+
+		
+
+pricing outfits "Hai outfits in human space"
+	import
+	location
+		government "Republic"
+	offset		
+		# Hai Outfits
+		"Boulder Reactor" -0.5 %
+		"Bullfrog Anti-Missile" -0.5 %
+		"Chameleon Anti-Missile" -0.5 %
+		"Geode Reactor" -0.5 %
+		"Hai Chasm Batteries" -0.5 %
+		"Hai Corundum Regenerator" -0.5 %
+		"Hai Cuttlefish Jammer" -0.5 %
+		"Hai Diamond Regenerator" -0.5 %
+		"Hai Fissure Batteries" -0.5 %
+		"Hai Gorge Batteries" -0.5 %
+		"Hai Octopus Jammer" -0.5 %
+		"Hai Ravine Batteries" -0.5 %
+		"Hai Tracker Pod" -0.5 %
+		"Hai Tracker" -0.5 %
+		"Hai Valley Batteries" -0.5 %
+		"Hai Williwaw Cooling" -0.5 %
+		"Holovid Zone" -0.5 %
+		"Ion Cannon" -0.5 %
+		"Pebble Core" -0.5 %
+		"Phantom Pallet" -0.5 %
+		"Pulse Cannon" -0.5 %
+		"Pulse Rifle" -0.5 %
+		"Pulse Turret" -0.5 %
+		"Sand Cell" -0.5 %
+		"Tracker Storage Pod" -0.5 %
+		"Value Detector" -0.5 %
+		`"Basrem" Atomic LTC` -0.5 %
+		`"Basrem" Atomic Steering` -0.5 %
+		`"Basrem" Atomic Thruster` -0.5 %
+		`"Basrem" Reverse Thruster` -0.5 %
+		`"Benga" Atomic LTC` -0.5 %
+		`"Benga" Atomic Steering` -0.5 %
+		`"Benga" Atomic Thruster` -0.5 %
+		`"Benga" Reverse Thruster` -0.5 %
+		`"Biroo" Atomic LTC` -0.5 %
+		`"Biroo" Atomic Steering` -0.5 %
+		`"Biroo" Atomic Thruster` -0.5 %
+		`"Biroo" Reverse Thruster` -0.5 %
+		`"Bondir" Atomic LTC` -0.5 %
+		`"Bondir" Atomic Steering` -0.5 %
+		`"Bondir" Atomic Thruster` -0.5 %
+		`"Bufaer" Atomic LTC` -0.5 %
+		`"Bufaer" Atomic Steering` -0.5 %
+		`"Bufaer" Atomic Thruster` -0.5 %

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -1079,8 +1079,9 @@ pricing outfits "Hai outfits in human space"
 	import
 	location
 		government "Free Worlds" "Neutral" "Republic" "Syndicate"
+	conditions
 		not event "hai-human treaty signed"
-	offset		
+	offset
 		# Hai Outfits
 		"Boulder Reactor" -0.5 %
 		"Bullfrog Anti-Missile" -0.5 %

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -975,7 +975,7 @@ pricing outfits "Human Not Interested in Alien Tech"
 		"High-Velocity Spike Rack" -0.5 %
 		"High-Velocity Spike" -0.5 %
 		"Kinetic Rail Rifle" -0.5 %
-		# Note: the Multimodal armor is not actually an outfit, but rather a mode for successor ship's armor. Thus selling it is just letting it revert to normal, there's no actual thing to sell.
+		# Note: the Multimodal Armor is not actually an outfit, but rather a mode for Successor ships' armor. Thus selling it is just letting it revert to normal; there's no actual thing to sell.
 		"Multimodal Armor: Keystone" -1 %
 		"Multimodal Armor: Heavy" -1 %
 		"Multimodal Armor: Regen" -1 %

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -785,7 +785,7 @@ pricing outfits "Human Not Interested in Alien Tech"
 	import
 	location
 		government "Free Worlds" "Neutral" "Republic" "Syndicate"
-		not planet "Wayfarer" "New Tortuga" "Rust"
+		not planet "Wayfarer" "New Tortuga" "Rust" "Valhalla"
 	value
 		# Rulei Outfits
 		"Fate Sealer" 1
@@ -1079,6 +1079,7 @@ pricing outfits "Hai outfits in human space"
 	import
 	location
 		government "Free Worlds" "Neutral" "Republic" "Syndicate"
+		not planet "Wayfarer" "New Tortuga" "Rust" "Valhalla"
 	conditions
 		not "event: hai-human treaty signed"
 	offset

--- a/data/human/sales.txt
+++ b/data/human/sales.txt
@@ -780,7 +780,7 @@ outfitter "Nuke"
 
 
 
-# Most standard outfitters are regular commercial enterprises that aren't interested in random alien technology. They mostly want to sell the player stuff, not be a source of profit for someone looting weird scrap metal from who knows where. Some, however, particularly R&D and independently-minded places, should be more interested. Wayfarer, New Tortuga, and Cratz come to mind, probably a few others out there too.
+# Most standard outfitters are regular commercial enterprises that aren't interested in random alien technology. They mostly want to sell the player stuff, not be a source of profit for someone looting weird scrap metal from who knows where. Some, however, particularly R&D and independently-minded places, should be more interested. Wayfarer, New Tortuga, and Kraz come to mind, probably a few others out there too.
 pricing outfits "Human Not Interested in Alien Tech"
 	import
 	location

--- a/data/persons.txt
+++ b/data/persons.txt
@@ -176,7 +176,7 @@ ship "Wardragon"
 		"Cargo Scanner"
 		"Outfit Scanner"
 		"Wanderer Ramscoop"
-			
+		
 		"Medium Graviton Thruster"
 		"Medium Graviton Steering"
 		"Medium Graviton LTC"

--- a/data/remnant/remnant sales.txt
+++ b/data/remnant/remnant sales.txt
@@ -195,7 +195,6 @@ pricing outfits "Remnant Valued Tech"
 		"Heatsink Partition" 0.2 %
 		"Inductive Extractor" 0.2 %
 		"Lantern Fission Core" 0.2 %
-		"Luxury Accommodations" 0.2 %
 		"Magnetic Scoop" 0.2 %
 		"Magnetoplasma Drive" 0.2 %
 		"Medium VLS" 0.2 %


### PR DESCRIPTION
**Content**
Have human outfitters contain more diversity of prices, and emphasize the planets with innovative industries.

## Problem:
Human outfitters are very homogenous. They all pay the same amount for stuff, they all sell things for the same price, there's very little to differentiate them other than whether or not they happen to have some particularly desireable outfit (looking at you, Deep outfitters with atomics).

## Goal:
Give players a reason to notice that there are good and bad places to buy and sell stuff. Ideally, there shouldn't be any one place that is the best to buy and sell, but a range of places that have their own strengths. These will probably tend to be places that have noteworthy features for outfitting or shipyards.

## Solution:
Pricing differences!

There are a lot of reasons why someplace might have different prices than other places. I'm not going to be able to hit all of them in this PR, but I hope to get enough broad strokes that people are inspired to refine it more in the future.

Some thoughts:
- Regular commercial outfitters should be uninterested in buying alien outfits. They're interested in making money selling things, not being a source of revenue for the player.
- Regular R&D outfitters, on the other hand, should be willing to do so. Most probably just normal prices, but some might pay extra for things related to what they focus on.
- The Deep, New Tortuga, and Tarazed have a bit more awareness of aliens out there than most, and likewise have invested in studying alien stuff more than others, so should probably at least pay normal prices, maybe even a little extra.
- Scrap yard planet. Maybe a dirt-belt planet somewhere that has an industry of scrapping ships, might sell a lot of common human outfits for dirt cheap as used or "refurbished." As a side idea, would be a great place to have a shipyard that sells a range of common human ships as bare hulls.
- Difference in prices will mean that outfit trading becomes a possibility. 

**Details:**
Right now, the following has been implemented:
- Quarg-friendly human and hai outfitters only take Quarg outfits at a steep discount.
- Quarg-hostile human and hai outfitters will pay a premium for Quarg outfits (not as much as the Remnant, but still a very nice increase)
- Human outfitters other than Wayfarer, New Tortuga, Valhalla, and Rust buy alien outfits at a discount. 
- Once the Hai and Humans have signed the treaty, human outfitters stop applying the penalty to hai outfits.
- Removed duplicated Remnant custom sales.
